### PR TITLE
Add TheSportsDB admin sync controls

### DIFF
--- a/wp-tsdb/assets/admin.js
+++ b/wp-tsdb/assets/admin.js
@@ -1,0 +1,73 @@
+(function($){
+    const apiBase = tsdbAdmin.rest;
+
+    async function populateCountries(){
+        const res = await fetch(apiBase + 'countries');
+        const data = await res.json();
+        const select = $('#tsdb_country').empty();
+        select.append('<option value="">Select Country</option>');
+        data.forEach(c => {
+            const name = c.name_en || c.name || c.strCountry;
+            select.append(`<option value="${name}">${name}</option>`);
+        });
+    }
+
+    async function populateSports(){
+        const res = await fetch(apiBase + 'sports');
+        const data = await res.json();
+        const select = $('#tsdb_sport').empty();
+        select.append('<option value="">Select Sport</option>');
+        data.forEach(s => {
+            const name = s.strSport || s.name;
+            select.append(`<option value="${name}">${name}</option>`);
+        });
+    }
+
+    async function populateLeagues(){
+        const country = $('#tsdb_country').val();
+        const sport = $('#tsdb_sport').val();
+        if(!country || !sport){ return; }
+        const res = await fetch(`${apiBase}leagues?country=${encodeURIComponent(country)}&sport=${encodeURIComponent(sport)}`);
+        const data = await res.json();
+        const select = $('#tsdb_league').empty();
+        select.append('<option value="">Select League</option>');
+        data.forEach(l => {
+            const id = l.idLeague || l.id;
+            const name = l.strLeague || l.name;
+            select.append(`<option value="${id}">${name}</option>`);
+        });
+    }
+
+    async function populateSeasons(){
+        const league = $('#tsdb_league').val();
+        if(!league){ return; }
+        const res = await fetch(`${apiBase}seasons?league=${encodeURIComponent(league)}`);
+        const data = await res.json();
+        const select = $('#tsdb_season').empty();
+        select.append('<option value="">Select Season</option>');
+        data.forEach(s => {
+            const name = s.strSeason || s.name;
+            select.append(`<option value="${name}">${name}</option>`);
+        });
+    }
+
+    $(function(){
+        populateCountries();
+        populateSports();
+        $('#tsdb_country, #tsdb_sport').on('change', populateLeagues);
+        $('#tsdb_league').on('change', populateSeasons);
+        $('#tsdb_sync_btn').on('click', function(e){
+            e.preventDefault();
+            const country = $('#tsdb_country').val();
+            const sport = $('#tsdb_sport').val();
+            $.post(ajaxurl, {
+                action: 'tsdb_sync_leagues',
+                country: country,
+                sport: sport,
+                _ajax_nonce: tsdbAdmin.nonce
+            }, function(resp){
+                alert(resp.data ? resp.data.message : 'Done');
+            });
+        });
+    });
+})(jQuery);

--- a/wp-tsdb/includes/admin-ui.php
+++ b/wp-tsdb/includes/admin-ui.php
@@ -1,0 +1,88 @@
+<?php
+namespace TSDB;
+
+/**
+ * Admin settings and sync controls.
+ */
+class Admin_UI {
+    protected $api_client;
+    protected $sync_manager;
+
+    public function __construct( Api_Client $api_client, Sync_Manager $sync_manager ) {
+        $this->api_client   = $api_client;
+        $this->sync_manager = $sync_manager;
+    }
+
+    public function init() {
+        add_action( 'admin_menu', [ $this, 'register_menu' ] );
+        add_action( 'admin_init', [ $this, 'register_settings' ] );
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
+        add_action( 'wp_ajax_tsdb_sync_leagues', [ $this, 'ajax_sync_leagues' ] );
+    }
+
+    public function register_menu() {
+        add_options_page( __( 'TheSportsDB', 'tsdb' ), __( 'TheSportsDB', 'tsdb' ), 'manage_options', 'tsdb', [ $this, 'settings_page' ] );
+    }
+
+    public function register_settings() {
+        register_setting( 'tsdb', 'tsdb_api_key', [ 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field', 'show_in_rest' => false ] );
+        register_setting( 'tsdb', 'tsdb_default_sport', [ 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field', 'default' => 'soccer' ] );
+        register_setting( 'tsdb', 'tsdb_live_poll', [ 'type' => 'integer', 'sanitize_callback' => 'absint', 'default' => 30 ] );
+    }
+
+    public function enqueue_scripts( $hook ) {
+        if ( 'settings_page_tsdb' !== $hook ) {
+            return;
+        }
+        wp_enqueue_script( 'tsdb-admin', TSDB_URL . 'assets/admin.js', [ 'jquery' ], TSDB_VERSION, true );
+        wp_localize_script( 'tsdb-admin', 'tsdbAdmin', [
+            'rest'  => esc_url_raw( rest_url( 'tsdb/v1/ref/' ) ),
+            'nonce' => wp_create_nonce( 'tsdb_sync' ),
+        ] );
+    }
+
+    public function ajax_sync_leagues() {
+        check_ajax_referer( 'tsdb_sync' );
+        $country = sanitize_text_field( $_POST['country'] ?? '' );
+        $sport   = sanitize_text_field( $_POST['sport'] ?? '' );
+        $count   = $this->sync_manager->sync_leagues( $country, $sport );
+        if ( is_wp_error( $count ) ) {
+            wp_send_json_error( $count->get_error_message() );
+        }
+        wp_send_json_success( [ 'message' => sprintf( __( '%d leagues synced', 'tsdb' ), $count ) ] );
+    }
+
+    public function settings_page() {
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'TheSportsDB Settings', 'tsdb' ); ?></h1>
+            <form method="post" action="options.php">
+                <?php settings_fields( 'tsdb' ); ?>
+                <table class="form-table" role="presentation">
+                    <tr>
+                        <th scope="row"><label for="tsdb_api_key">API Key</label></th>
+                        <td><input name="tsdb_api_key" type="text" id="tsdb_api_key" value="<?php echo esc_attr( get_option( 'tsdb_api_key', '' ) ); ?>" class="regular-text"></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="tsdb_default_sport">Default Sport</label></th>
+                        <td><input name="tsdb_default_sport" type="text" id="tsdb_default_sport" value="<?php echo esc_attr( get_option( 'tsdb_default_sport', 'soccer' ) ); ?>" class="regular-text"></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="tsdb_live_poll">Live Poll Interval (s)</label></th>
+                        <td><input name="tsdb_live_poll" type="number" id="tsdb_live_poll" value="<?php echo esc_attr( get_option( 'tsdb_live_poll', 30 ) ); ?>" class="small-text"></td>
+                    </tr>
+                </table>
+                <?php submit_button(); ?>
+            </form>
+            <h2><?php esc_html_e( 'Sync Data', 'tsdb' ); ?></h2>
+            <div id="tsdb_sync_controls">
+                <select id="tsdb_country"></select>
+                <select id="tsdb_sport"></select>
+                <select id="tsdb_league"></select>
+                <select id="tsdb_season"></select>
+                <button id="tsdb_sync_btn" class="button button-primary"><?php esc_html_e( 'Sync Selected', 'tsdb' ); ?></button>
+            </div>
+        </div>
+        <?php
+    }
+}

--- a/wp-tsdb/includes/api-client.php
+++ b/wp-tsdb/includes/api-client.php
@@ -1,0 +1,97 @@
+<?php
+namespace TSDB;
+
+/**
+ * Simple API client for TheSportsDB.
+ */
+class Api_Client {
+    protected $logger;
+    protected $rate_limiter;
+    protected $base_v1 = 'https://www.thesportsdb.com/api/v1/json';
+    protected $base_v2 = 'https://www.thesportsdb.com/api/v2/json';
+
+    public function __construct( Logger $logger, Rate_Limiter $rate_limiter ) {
+        $this->logger       = $logger;
+        $this->rate_limiter = $rate_limiter;
+    }
+
+    /**
+     * Perform GET request to API.
+     *
+     * @param string $endpoint Endpoint path e.g. '/search_all_leagues.php'.
+     * @param array  $params   Query parameters.
+     * @param bool   $v2       Whether to use v2 API.
+     *
+     * @return array|WP_Error
+     */
+    public function get( $endpoint, $params = [], $v2 = false ) {
+        $key = get_option( 'tsdb_api_key' );
+        if ( empty( $key ) ) {
+            return new \WP_Error( 'tsdb_no_key', __( 'API key not set', 'tsdb' ) );
+        }
+        if ( ! $this->rate_limiter->allow() ) {
+            return new \WP_Error( 'tsdb_rate_limited', __( 'Rate limit exceeded', 'tsdb' ) );
+        }
+
+        $base = $v2 ? $this->base_v2 : $this->base_v1;
+        $url  = sprintf( '%s/%s%s', $base, $key, $endpoint );
+        if ( ! empty( $params ) ) {
+            $url = add_query_arg( $params, $url );
+        }
+        $response = wp_remote_get( $url, [ 'timeout' => 20 ] );
+        if ( is_wp_error( $response ) ) {
+            $this->logger->error( 'api', $response->get_error_message() );
+            return $response;
+        }
+        $code = wp_remote_retrieve_response_code( $response );
+        if ( $code >= 400 ) {
+            $this->logger->error( 'api', 'HTTP ' . $code . ' for ' . $endpoint );
+            return new \WP_Error( 'tsdb_http_' . $code, 'HTTP ' . $code );
+        }
+
+        $body = wp_remote_retrieve_body( $response );
+        $data = json_decode( $body, true );
+        return $data;
+    }
+
+    /**
+     * Convenience wrapper to list all sports.
+     *
+     * @return array|\WP_Error
+     */
+    public function sports() {
+        return $this->get( '/all_sports.php' );
+    }
+
+    /**
+     * List all countries supported by the API.
+     *
+     * @return array|\WP_Error
+     */
+    public function countries() {
+        return $this->get( '/all_countries.php' );
+    }
+
+    /**
+     * List leagues for a country and sport.
+     *
+     * @param string $country Country name.
+     * @param string $sport   Sport name.
+     *
+     * @return array|\WP_Error
+     */
+    public function leagues( $country, $sport ) {
+        return $this->get( '/search_all_leagues.php', [ 'c' => $country, 's' => $sport ] );
+    }
+
+    /**
+     * List seasons for a league.
+     *
+     * @param string $league_id External league ID.
+     *
+     * @return array|\WP_Error
+     */
+    public function seasons( $league_id ) {
+        return $this->get( '/search_all_seasons.php', [ 'id' => $league_id ] );
+    }
+}

--- a/wp-tsdb/includes/logger.php
+++ b/wp-tsdb/includes/logger.php
@@ -1,0 +1,30 @@
+<?php
+namespace TSDB;
+
+/**
+ * Basic logger writing into custom table.
+ */
+class Logger {
+    public function log( $level, $source, $message, $context = [] ) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'tsdb_logs';
+        $wpdb->insert(
+            $table,
+            [
+                'level'        => $level,
+                'source'       => $source,
+                'message'      => $message,
+                'context_json' => wp_json_encode( $context ),
+            ],
+            [ '%s', '%s', '%s', '%s' ]
+        );
+    }
+
+    public function error( $source, $message, $context = [] ) {
+        $this->log( 'error', $source, $message, $context );
+    }
+
+    public function info( $source, $message, $context = [] ) {
+        $this->log( 'info', $source, $message, $context );
+    }
+}

--- a/wp-tsdb/includes/rate-limiter.php
+++ b/wp-tsdb/includes/rate-limiter.php
@@ -1,0 +1,20 @@
+<?php
+namespace TSDB;
+
+/**
+ * Simple token bucket rate limiter stored in transients.
+ */
+class Rate_Limiter {
+    protected $limit_per_min = 90; // tokens per minute
+    protected $bucket_key    = 'tsdb_tokens';
+
+    public function allow() {
+        $tokens = get_transient( $this->bucket_key );
+        $tokens = false === $tokens ? $this->limit_per_min : (int) $tokens;
+        if ( $tokens <= 0 ) {
+            return false;
+        }
+        set_transient( $this->bucket_key, $tokens - 1, MINUTE_IN_SECONDS );
+        return true;
+    }
+}

--- a/wp-tsdb/includes/rest-api.php
+++ b/wp-tsdb/includes/rest-api.php
@@ -1,0 +1,101 @@
+<?php
+namespace TSDB;
+
+/**
+ * Minimal REST API endpoints for blocks and admin UI.
+ */
+class Rest_API {
+    protected $api;
+
+    public function __construct( Api_Client $api ) {
+        $this->api = $api;
+    }
+
+    public function register_routes() {
+        add_action( 'rest_api_init', function () {
+            register_rest_route( 'tsdb/v1', '/leagues', [
+                'methods'  => 'GET',
+                'callback' => [ $this, 'get_leagues' ],
+                'permission_callback' => '__return_true',
+            ] );
+            register_rest_route( 'tsdb/v1', '/fixtures', [
+                'methods'  => 'GET',
+                'callback' => [ $this, 'get_fixtures' ],
+                'permission_callback' => '__return_true',
+            ] );
+            register_rest_route( 'tsdb/v1', '/ref/countries', [
+                'methods'  => 'GET',
+                'callback' => [ $this, 'remote_countries' ],
+                'permission_callback' => '__return_true',
+            ] );
+            register_rest_route( 'tsdb/v1', '/ref/sports', [
+                'methods'  => 'GET',
+                'callback' => [ $this, 'remote_sports' ],
+                'permission_callback' => '__return_true',
+            ] );
+            register_rest_route( 'tsdb/v1', '/ref/leagues', [
+                'methods'  => 'GET',
+                'callback' => [ $this, 'remote_leagues' ],
+                'permission_callback' => '__return_true',
+            ] );
+            register_rest_route( 'tsdb/v1', '/ref/seasons', [
+                'methods'  => 'GET',
+                'callback' => [ $this, 'remote_seasons' ],
+                'permission_callback' => '__return_true',
+            ] );
+        } );
+    }
+
+    public function get_leagues( $request ) {
+        global $wpdb;
+        $country = sanitize_text_field( $request->get_param( 'country' ) );
+        $sport   = sanitize_text_field( $request->get_param( 'sport' ) );
+        $table   = $wpdb->prefix . 'tsdb_leagues';
+        $where   = '1=1';
+        $args    = [];
+        if ( $country ) {
+            $where  .= ' AND country = %s';
+            $args[]  = $country;
+        }
+        if ( $sport ) {
+            $where  .= ' AND sport = %s';
+            $args[]  = $sport;
+        }
+        $sql = $wpdb->prepare( "SELECT * FROM {$table} WHERE {$where} ORDER BY name", $args );
+        $rows = $wpdb->get_results( $sql );
+        return rest_ensure_response( $rows );
+    }
+
+    public function get_fixtures( $request ) {
+        global $wpdb;
+        $league = absint( $request->get_param( 'league' ) );
+        $status = sanitize_text_field( $request->get_param( 'status' ) );
+        $table  = $wpdb->prefix . 'tsdb_events';
+        $sql    = $wpdb->prepare( "SELECT * FROM {$table} WHERE league_id=%d AND status=%s ORDER BY utc_start ASC", $league, $status );
+        $rows   = $wpdb->get_results( $sql );
+        return rest_ensure_response( $rows );
+    }
+
+    public function remote_countries() {
+        $data = $this->api->countries();
+        return rest_ensure_response( $data['countries'] ?? [] );
+    }
+
+    public function remote_sports() {
+        $data = $this->api->sports();
+        return rest_ensure_response( $data['sports'] ?? [] );
+    }
+
+    public function remote_leagues( $request ) {
+        $country = sanitize_text_field( $request->get_param( 'country' ) );
+        $sport   = sanitize_text_field( $request->get_param( 'sport' ) );
+        $data    = $this->api->leagues( $country, $sport );
+        return rest_ensure_response( $data['countrys'] ?? [] );
+    }
+
+    public function remote_seasons( $request ) {
+        $league = sanitize_text_field( $request->get_param( 'league' ) );
+        $data   = $this->api->seasons( $league );
+        return rest_ensure_response( $data['seasons'] ?? [] );
+    }
+}

--- a/wp-tsdb/includes/sync-manager.php
+++ b/wp-tsdb/includes/sync-manager.php
@@ -1,0 +1,65 @@
+<?php
+namespace TSDB;
+
+/**
+ * Handles synchronization jobs with TheSportsDB API.
+ */
+class Sync_Manager {
+    protected $api;
+    protected $logger;
+
+    public function __construct( Api_Client $api, Logger $logger ) {
+        $this->api    = $api;
+        $this->logger = $logger;
+    }
+
+    public function init_cron() {
+        add_action( 'tsdb_cron_tick', [ $this, 'cron_tick' ] );
+        if ( ! wp_next_scheduled( 'tsdb_cron_tick' ) ) {
+            wp_schedule_event( time(), 'minute', 'tsdb_cron_tick' );
+        }
+        add_filter( 'cron_schedules', function ( $schedules ) {
+            if ( ! isset( $schedules['minute'] ) ) {
+                $schedules['minute'] = [ 'interval' => 60, 'display' => __( 'Every Minute' ) ];
+            }
+            return $schedules;
+        } );
+    }
+
+    public function cron_tick() {
+        // Placeholder for cron jobs: update live events etc.
+        $this->logger->info( 'cron', 'tick' );
+    }
+
+    /**
+     * Import leagues by country and sport.
+     */
+    public function sync_leagues( $country, $sport ) {
+        $data = $this->api->get( '/search_all_leagues.php', [ 'c' => $country, 's' => $sport ] );
+        if ( is_wp_error( $data ) ) {
+            return $data;
+        }
+        if ( empty( $data['countrys'] ) ) {
+            return 0;
+        }
+        global $wpdb;
+        $table = $wpdb->prefix . 'tsdb_leagues';
+        $count = 0;
+        foreach ( $data['countrys'] as $row ) {
+            $wpdb->replace(
+                $table,
+                [
+                    'ext_id'        => $row['idLeague'],
+                    'sport'         => $row['strSport'],
+                    'country'       => $row['strCountry'],
+                    'name'          => $row['strLeague'],
+                    'season_current'=> $row['strCurrentSeason'],
+                    'logo_url'      => $row['strLogo'],
+                ],
+                [ '%s', '%s', '%s', '%s', '%s', '%s' ]
+            );
+            $count++;
+        }
+        return $count;
+    }
+}

--- a/wp-tsdb/readme.txt
+++ b/wp-tsdb/readme.txt
@@ -1,0 +1,9 @@
+=== TheSportsDB Sync ===
+Contributors: openai
+Tags: sports, api, thesportsdb
+Requires at least: 5.8
+Tested up to: 6.4
+Stable tag: 0.1.0
+License: GPLv2 or later
+
+Multisport synchronization plugin for TheSportsDB premium API. Provides database tables, REST endpoints, and admin settings.

--- a/wp-tsdb/tsdb.php
+++ b/wp-tsdb/tsdb.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Plugin Name: TheSportsDB Sync
+ * Description: Multisport synchronization plugin for TheSportsDB premium API.
+ * Version: 0.1.0
+ * Author: OpenAI
+ * Text Domain: tsdb
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+// Define plugin constants.
+if ( ! defined( 'TSDB_VERSION' ) ) {
+    define( 'TSDB_VERSION', '0.1.0' );
+}
+if ( ! defined( 'TSDB_PATH' ) ) {
+    define( 'TSDB_PATH', plugin_dir_path( __FILE__ ) );
+}
+if ( ! defined( 'TSDB_URL' ) ) {
+    define( 'TSDB_URL', plugin_dir_url( __FILE__ ) );
+}
+
+// Simple PSR-4 style autoloader for plugin classes.
+spl_autoload_register( function ( $class ) {
+    if ( 0 !== strpos( $class, 'TSDB\\' ) ) {
+        return;
+    }
+
+    $path = TSDB_PATH . 'includes/' . strtolower( str_replace( 'TSDB\\', '', $class ) );
+    $path = str_replace( '\\', '/', $path ) . '.php';
+
+    if ( file_exists( $path ) ) {
+        include $path;
+    }
+} );
+
+/**
+ * Initialize plugin services.
+ */
+function tsdb_init_plugin() {
+    // Instantiate core services.
+    $logger       = new TSDB\Logger();
+    $rate_limiter = new TSDB\Rate_Limiter();
+    $api_client   = new TSDB\Api_Client( $logger, $rate_limiter );
+    $sync_manager = new TSDB\Sync_Manager( $api_client, $logger );
+    $rest_api     = new TSDB\Rest_API( $api_client );
+    $admin_ui     = new TSDB\Admin_UI( $api_client, $sync_manager );
+
+    // Boot services.
+    $rest_api->register_routes();
+    $admin_ui->init();
+    $sync_manager->init_cron();
+}
+add_action( 'plugins_loaded', 'tsdb_init_plugin' );
+
+/**
+ * Plugin activation: create required database tables.
+ */
+function tsdb_activate() {
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    global $wpdb;
+    $charset_collate = $wpdb->get_charset_collate();
+
+    $tables = [];
+
+    $prefix = $wpdb->prefix . 'tsdb_';
+    $tables["{$prefix}leagues"] = "CREATE TABLE {$prefix}leagues (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        ext_id varchar(50) NOT NULL,
+        sport varchar(50) NOT NULL,
+        country varchar(100) NOT NULL,
+        name varchar(255) NOT NULL,
+        season_current varchar(25) DEFAULT NULL,
+        logo_url text DEFAULT NULL,
+        updated_at datetime DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (id),
+        KEY ext_id (ext_id)
+    ) $charset_collate";
+
+    $tables["{$prefix}seasons"] = "CREATE TABLE {$prefix}seasons (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        league_id bigint(20) unsigned NOT NULL,
+        name varchar(100) NOT NULL,
+        year_start smallint NOT NULL,
+        year_end smallint NOT NULL,
+        ext_id varchar(50) NOT NULL,
+        PRIMARY KEY (id),
+        KEY league_id (league_id)
+    ) $charset_collate";
+
+    $tables["{$prefix}teams"] = "CREATE TABLE {$prefix}teams (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        league_id bigint(20) unsigned NOT NULL,
+        name varchar(255) NOT NULL,
+        short_name varchar(100) DEFAULT NULL,
+        ext_id varchar(50) NOT NULL,
+        badge_url text DEFAULT NULL,
+        venue_id bigint(20) unsigned DEFAULT NULL,
+        country varchar(100) DEFAULT NULL,
+        founded int DEFAULT NULL,
+        socials_json longtext DEFAULT NULL,
+        PRIMARY KEY (id),
+        KEY league_id (league_id),
+        KEY ext_id (ext_id)
+    ) $charset_collate";
+
+    $tables["{$prefix}players"] = "CREATE TABLE {$prefix}players (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        team_id bigint(20) unsigned NOT NULL,
+        name varchar(255) NOT NULL,
+        pos varchar(10) DEFAULT NULL,
+        ext_id varchar(50) NOT NULL,
+        thumb_url text DEFAULT NULL,
+        number varchar(20) DEFAULT NULL,
+        nationality varchar(100) DEFAULT NULL,
+        dob date DEFAULT NULL,
+        bio_json longtext DEFAULT NULL,
+        PRIMARY KEY (id),
+        KEY team_id (team_id),
+        KEY ext_id (ext_id)
+    ) $charset_collate";
+
+    $tables["{$prefix}venues"] = "CREATE TABLE {$prefix}venues (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        name varchar(255) NOT NULL,
+        city varchar(100) DEFAULT NULL,
+        country varchar(100) DEFAULT NULL,
+        ext_id varchar(50) NOT NULL,
+        image_url text DEFAULT NULL,
+        capacity int DEFAULT NULL,
+        lat decimal(10,6) DEFAULT NULL,
+        lng decimal(10,6) DEFAULT NULL,
+        PRIMARY KEY (id),
+        KEY ext_id (ext_id)
+    ) $charset_collate";
+
+    $tables["{$prefix}events"] = "CREATE TABLE {$prefix}events (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        league_id bigint(20) unsigned NOT NULL,
+        season_id bigint(20) unsigned NOT NULL,
+        home_id bigint(20) unsigned NOT NULL,
+        away_id bigint(20) unsigned NOT NULL,
+        venue_id bigint(20) unsigned DEFAULT NULL,
+        ext_id varchar(50) NOT NULL,
+        status varchar(20) NOT NULL DEFAULT 'scheduled',
+        utc_start datetime NOT NULL,
+        home_score int DEFAULT NULL,
+        away_score int DEFAULT NULL,
+        round varchar(50) DEFAULT NULL,
+        stage varchar(50) DEFAULT NULL,
+        elapsed int DEFAULT NULL,
+        period varchar(20) DEFAULT NULL,
+        ref_json longtext DEFAULT NULL,
+        tv_json longtext DEFAULT NULL,
+        odds_json longtext DEFAULT NULL,
+        weather_json longtext DEFAULT NULL,
+        updated_at datetime DEFAULT CURRENT_TIMESTAMP,
+        checksum varchar(32) DEFAULT NULL,
+        PRIMARY KEY (id),
+        KEY league_season (league_id,season_id),
+        KEY status_start (status, utc_start),
+        KEY ext_id (ext_id)
+    ) $charset_collate";
+
+    $tables["{$prefix}event_timeline"] = "CREATE TABLE {$prefix}event_timeline (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        event_id bigint(20) unsigned NOT NULL,
+        minute int DEFAULT NULL,
+        type varchar(50) NOT NULL,
+        team_id bigint(20) unsigned DEFAULT NULL,
+        player_id bigint(20) unsigned DEFAULT NULL,
+        assist_id bigint(20) unsigned DEFAULT NULL,
+        detail_json longtext DEFAULT NULL,
+        PRIMARY KEY (id),
+        KEY event_id (event_id)
+    ) $charset_collate";
+
+    $tables["{$prefix}event_stats"] = "CREATE TABLE {$prefix}event_stats (
+        event_id bigint(20) unsigned NOT NULL,
+        stats_json longtext DEFAULT NULL,
+        PRIMARY KEY (event_id)
+    ) $charset_collate";
+
+    $tables["{$prefix}standings"] = "CREATE TABLE {$prefix}standings (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        league_id bigint(20) unsigned NOT NULL,
+        season_id bigint(20) unsigned NOT NULL,
+        table_json longtext DEFAULT NULL,
+        updated_at datetime DEFAULT CURRENT_TIMESTAMP,
+        checksum varchar(32) DEFAULT NULL,
+        PRIMARY KEY (id),
+        KEY league_season (league_id,season_id)
+    ) $charset_collate";
+
+    $tables["{$prefix}broadcast"] = "CREATE TABLE {$prefix}broadcast (
+        league_id bigint(20) unsigned NOT NULL,
+        season_id bigint(20) unsigned NOT NULL,
+        date_utc date NOT NULL,
+        country varchar(100) NOT NULL,
+        channel varchar(200) NOT NULL,
+        payload_json longtext DEFAULT NULL,
+        PRIMARY KEY (league_id, season_id, date_utc, country, channel)
+    ) $charset_collate";
+
+    $tables["{$prefix}cache"] = "CREATE TABLE {$prefix}cache (
+        cache_key varchar(191) NOT NULL,
+        value mediumtext NOT NULL,
+        ttl int NOT NULL,
+        created_at datetime DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (cache_key)
+    ) $charset_collate";
+
+    $tables["{$prefix}logs"] = "CREATE TABLE {$prefix}logs (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        ts datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        level varchar(20) NOT NULL,
+        source varchar(100) NOT NULL,
+        message text NOT NULL,
+        context_json longtext DEFAULT NULL,
+        PRIMARY KEY (id),
+        KEY ts (ts)
+    ) $charset_collate";
+
+    foreach ( $tables as $sql ) {
+        dbDelta( $sql );
+    }
+}
+register_activation_hook( __FILE__, 'tsdb_activate' );
+
+/**
+ * Deactivation: clear scheduled events.
+ */
+function tsdb_deactivate() {
+    wp_clear_scheduled_hook( 'tsdb_cron_tick' );
+}
+register_deactivation_hook( __FILE__, 'tsdb_deactivate' );
+


### PR DESCRIPTION
## Summary
- add API client helpers for sports, countries, leagues and seasons
- expose reference REST endpoints for admin dropdowns
- add JS-powered admin UI to select country → sport → league → season and trigger sync

## Testing
- `php -l wp-tsdb/tsdb.php`
- `php -l wp-tsdb/includes/api-client.php`
- `php -l wp-tsdb/includes/rest-api.php`
- `php -l wp-tsdb/includes/admin-ui.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb80bbbc108328964f69a5c0042068