### PR TITLE
Add season, team, and event syncing

### DIFF
--- a/wp-tsdb/assets/admin.js
+++ b/wp-tsdb/assets/admin.js
@@ -69,5 +69,31 @@
                 alert(resp.data ? resp.data.message : 'Done');
             });
         });
+        $('#tsdb_seed_btn').on('click', function(e){
+            e.preventDefault();
+            const league = $('#tsdb_league').val();
+            const season = $('#tsdb_season').val();
+            $.post(ajaxurl, {
+                action: 'tsdb_seed',
+                league: league,
+                season: season,
+                _ajax_nonce: tsdbAdmin.nonce
+            }, function(resp){
+                alert(resp.data ? resp.data.message : 'Done');
+            });
+        });
+        $('#tsdb_delta_btn').on('click', function(e){
+            e.preventDefault();
+            const league = $('#tsdb_league').val();
+            const season = $('#tsdb_season').val();
+            $.post(ajaxurl, {
+                action: 'tsdb_delta',
+                league: league,
+                season: season,
+                _ajax_nonce: tsdbAdmin.nonce
+            }, function(resp){
+                alert(resp.data ? resp.data.message : 'Done');
+            });
+        });
     });
 })(jQuery);

--- a/wp-tsdb/includes/sync-manager.php
+++ b/wp-tsdb/includes/sync-manager.php
@@ -27,8 +27,14 @@ class Sync_Manager {
     }
 
     public function cron_tick() {
-        // Placeholder for cron jobs: update live events etc.
         $this->logger->info( 'cron', 'tick' );
+        global $wpdb;
+        $leagues = $wpdb->get_results( "SELECT ext_id, season_current FROM {$wpdb->prefix}tsdb_leagues" );
+        foreach ( $leagues as $league ) {
+            if ( ! empty( $league->season_current ) ) {
+                $this->sync_events( $league->ext_id, $league->season_current );
+            }
+        }
     }
 
     /**
@@ -57,6 +63,166 @@ class Sync_Manager {
                     'logo_url'      => $row['strLogo'],
                 ],
                 [ '%s', '%s', '%s', '%s', '%s', '%s' ]
+            );
+            $count++;
+        }
+        return $count;
+    }
+
+    /**
+     * Import seasons for a league.
+     *
+     * @param string $league_ext_id External league ID.
+     * @return int|\WP_Error
+     */
+    public function sync_seasons( $league_ext_id ) {
+        $data = $this->api->get( '/search_all_seasons.php', [ 'id' => $league_ext_id ] );
+        if ( is_wp_error( $data ) ) {
+            return $data;
+        }
+        if ( empty( $data['seasons'] ) ) {
+            return 0;
+        }
+        global $wpdb;
+        $league_id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$wpdb->prefix}tsdb_leagues WHERE ext_id = %s", $league_ext_id ) );
+        if ( ! $league_id ) {
+            return new \WP_Error( 'tsdb_missing_league', __( 'League not found', 'tsdb' ) );
+        }
+        $table = $wpdb->prefix . 'tsdb_seasons';
+        $count = 0;
+        foreach ( $data['seasons'] as $row ) {
+            $name = $row['strSeason'] ?? '';
+            if ( ! $name ) {
+                continue;
+            }
+            $year_start = $year_end = 0;
+            if ( preg_match( '/(\d{4})[\/-](\d{4})/', $name, $m ) ) {
+                $year_start = intval( $m[1] );
+                $year_end   = intval( $m[2] );
+            }
+            $wpdb->replace(
+                $table,
+                [
+                    'league_id' => $league_id,
+                    'name'      => $name,
+                    'year_start'=> $year_start,
+                    'year_end'  => $year_end,
+                    'ext_id'    => $row['idSeason'] ?? $name,
+                ],
+                [ '%d', '%s', '%d', '%d', '%s' ]
+            );
+            $count++;
+        }
+        return $count;
+    }
+
+    /**
+     * Import teams for a league.
+     *
+     * @param string $league_ext_id External league ID.
+     * @return int|\WP_Error
+     */
+    public function sync_teams( $league_ext_id ) {
+        $data = $this->api->get( '/lookup_all_teams.php', [ 'id' => $league_ext_id ] );
+        if ( is_wp_error( $data ) ) {
+            return $data;
+        }
+        if ( empty( $data['teams'] ) ) {
+            return 0;
+        }
+        global $wpdb;
+        $league_id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$wpdb->prefix}tsdb_leagues WHERE ext_id = %s", $league_ext_id ) );
+        if ( ! $league_id ) {
+            return new \WP_Error( 'tsdb_missing_league', __( 'League not found', 'tsdb' ) );
+        }
+        $table = $wpdb->prefix . 'tsdb_teams';
+        $count = 0;
+        foreach ( $data['teams'] as $row ) {
+            $wpdb->replace(
+                $table,
+                [
+                    'league_id'   => $league_id,
+                    'name'        => $row['strTeam'] ?? '',
+                    'short_name'  => $row['strTeamShort'] ?? null,
+                    'ext_id'      => $row['idTeam'] ?? '',
+                    'badge_url'   => $row['strTeamBadge'] ?? null,
+                    'venue_id'    => null,
+                    'country'     => $row['strCountry'] ?? null,
+                    'founded'     => isset( $row['intFormedYear'] ) ? intval( $row['intFormedYear'] ) : null,
+                    'socials_json'=> ! empty( $row['strTwitter'] ) || ! empty( $row['strFacebook'] ) || ! empty( $row['strInstagram'] ) ? wp_json_encode( [
+                        'twitter'   => $row['strTwitter'] ?? '',
+                        'facebook'  => $row['strFacebook'] ?? '',
+                        'instagram' => $row['strInstagram'] ?? '',
+                    ] ) : null,
+                ],
+                [ '%d','%s','%s','%s','%s','%d','%s','%d','%s' ]
+            );
+            $count++;
+        }
+        return $count;
+    }
+
+    /**
+     * Import events for a league and season.
+     *
+     * @param string $league_ext_id External league ID.
+     * @param string $season Season name, e.g. '2023-2024'.
+     * @return int|\WP_Error
+     */
+    public function sync_events( $league_ext_id, $season ) {
+        $data = $this->api->get( '/eventsseason.php', [ 'id' => $league_ext_id, 's' => $season ] );
+        if ( is_wp_error( $data ) ) {
+            return $data;
+        }
+        if ( empty( $data['events'] ) ) {
+            return 0;
+        }
+        global $wpdb;
+        $league_id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$wpdb->prefix}tsdb_leagues WHERE ext_id = %s", $league_ext_id ) );
+        if ( ! $league_id ) {
+            return new \WP_Error( 'tsdb_missing_league', __( 'League not found', 'tsdb' ) );
+        }
+        $season_id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$wpdb->prefix}tsdb_seasons WHERE league_id = %d AND name = %s", $league_id, $season ) );
+        if ( ! $season_id ) {
+            $this->sync_seasons( $league_ext_id );
+            $season_id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$wpdb->prefix}tsdb_seasons WHERE league_id = %d AND name = %s", $league_id, $season ) );
+        }
+        $table      = $wpdb->prefix . 'tsdb_events';
+        $team_table = $wpdb->prefix . 'tsdb_teams';
+        $count = 0;
+        foreach ( $data['events'] as $row ) {
+            $home_id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$team_table} WHERE ext_id = %s", $row['idHomeTeam'] ?? '' ) );
+            $away_id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$team_table} WHERE ext_id = %s", $row['idAwayTeam'] ?? '' ) );
+            if ( ! $home_id || ! $away_id ) {
+                $this->sync_teams( $league_ext_id );
+                $home_id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$team_table} WHERE ext_id = %s", $row['idHomeTeam'] ?? '' ) );
+                $away_id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$team_table} WHERE ext_id = %s", $row['idAwayTeam'] ?? '' ) );
+            }
+            if ( ! $home_id || ! $away_id ) {
+                continue;
+            }
+            $utc_start = null;
+            if ( ! empty( $row['dateEvent'] ) ) {
+                $time      = $row['strTime'] ?? '00:00:00';
+                $utc_start = gmdate( 'Y-m-d H:i:s', strtotime( $row['dateEvent'] . ' ' . $time . ' UTC' ) );
+            }
+            $wpdb->replace(
+                $table,
+                [
+                    'league_id'  => $league_id,
+                    'season_id'  => $season_id,
+                    'home_id'    => $home_id,
+                    'away_id'    => $away_id,
+                    'venue_id'   => null,
+                    'ext_id'     => $row['idEvent'] ?? '',
+                    'status'     => $row['strStatus'] ?? ( isset( $row['intHomeScore'] ) ? 'finished' : 'scheduled' ),
+                    'utc_start'  => $utc_start,
+                    'home_score' => isset( $row['intHomeScore'] ) ? intval( $row['intHomeScore'] ) : null,
+                    'away_score' => isset( $row['intAwayScore'] ) ? intval( $row['intAwayScore'] ) : null,
+                    'round'      => $row['intRound'] ?? null,
+                    'stage'      => $row['strStage'] ?? null,
+                ],
+                [ '%d','%d','%d','%d','%d','%s','%s','%s','%d','%d','%s','%s' ]
             );
             $count++;
         }


### PR DESCRIPTION
## Summary
- add seasons, teams, and events synchronization using Api_Client and wpdb
- wire cron tick and admin AJAX actions to trigger new sync methods
- extend admin UI/JS with seed and refresh controls

## Testing
- `php -l wp-tsdb/includes/sync-manager.php`
- `php -l wp-tsdb/includes/admin-ui.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb83b22a148328b242ffc6e3dc38d9