### PR TITLE
Add persistent cache store with TTLs and invalidation

### DIFF
--- a/wp-tsdb/includes/cache-store.php
+++ b/wp-tsdb/includes/cache-store.php
@@ -1,0 +1,86 @@
+<?php
+namespace TSDB;
+
+/**
+ * Persistent cache with object cache fallback to DB table.
+ */
+class Cache_Store {
+    protected $group = 'tsdb';
+    protected $table;
+
+    public function __construct() {
+        global $wpdb;
+        $this->table = $wpdb->prefix . 'tsdb_cache';
+    }
+
+    /**
+     * Retrieve a value from cache.
+     *
+     * @param string $key Cache key.
+     * @return mixed|false
+     */
+    public function get( $key ) {
+        $found = false;
+        $value = wp_cache_get( $key, $this->group, false, $found );
+        if ( $found ) {
+            return $value;
+        }
+        global $wpdb;
+        $row = $wpdb->get_row( $wpdb->prepare( "SELECT value, ttl, UNIX_TIMESTAMP(created_at) AS created FROM {$this->table} WHERE cache_key=%s", $key ) );
+        if ( ! $row ) {
+            return false;
+        }
+        if ( $row->ttl > 0 && ( $row->created + $row->ttl ) < time() ) {
+            $this->delete( $key );
+            return false;
+        }
+        $value = maybe_unserialize( $row->value );
+        $ttl   = $row->ttl > 0 ? ( $row->created + $row->ttl ) - time() : 0;
+        if ( $ttl > 0 ) {
+            wp_cache_set( $key, $value, $this->group, $ttl );
+        }
+        return $value;
+    }
+
+    /**
+     * Store a value in cache.
+     *
+     * @param string $key   Cache key.
+     * @param mixed  $value Value to store.
+     * @param int    $ttl   Time to live in seconds.
+     */
+    public function set( $key, $value, $ttl = 0 ) {
+        wp_cache_set( $key, $value, $this->group, $ttl );
+        global $wpdb;
+        $wpdb->replace(
+            $this->table,
+            [
+                'cache_key'  => $key,
+                'value'      => maybe_serialize( $value ),
+                'ttl'        => (int) $ttl,
+                'created_at' => current_time( 'mysql', 1 ),
+            ],
+            [ '%s', '%s', '%d', '%s' ]
+        );
+    }
+
+    /**
+     * Delete an entry from cache.
+     *
+     * @param string $key Cache key.
+     */
+    public function delete( $key ) {
+        wp_cache_delete( $key, $this->group );
+        global $wpdb;
+        $wpdb->delete( $this->table, [ 'cache_key' => $key ], [ '%s' ] );
+    }
+
+    /**
+     * Flush all cache entries.
+     */
+    public function flush() {
+        wp_cache_flush();
+        global $wpdb;
+        $wpdb->query( "TRUNCATE TABLE {$this->table}" );
+    }
+}

--- a/wp-tsdb/includes/sync-manager.php
+++ b/wp-tsdb/includes/sync-manager.php
@@ -7,12 +7,14 @@ namespace TSDB;
 class Sync_Manager {
     protected $api;
     protected $logger;
+    protected $cache;
     protected $next_runs = [];
     protected $active_leagues = [];
 
-    public function __construct( Api_Client $api, Logger $logger ) {
+    public function __construct( Api_Client $api, Logger $logger, Cache_Store $cache ) {
         $this->api    = $api;
         $this->logger = $logger;
+        $this->cache  = $cache;
         $this->next_runs     = get_option( 'tsdb_sync_next_runs', [] );
         $this->active_leagues = get_option( 'tsdb_active_leagues', [] );
     }
@@ -331,6 +333,12 @@ class Sync_Manager {
                 [ '%d','%d','%d','%d','%d','%s','%s','%s','%d','%d','%s','%s' ]
             );
             $count++;
+        }
+        if ( $count ) {
+            $this->cache->delete( 'fixtures_' . $league_id . '_scheduled' );
+            $this->cache->delete( 'fixtures_' . $league_id . '_live' );
+            $this->cache->delete( 'fixtures_' . $league_id . '_inplay' );
+            $this->cache->delete( 'fixtures_' . $league_id . '_finished' );
         }
         return $count;
     }

--- a/wp-tsdb/tsdb.php
+++ b/wp-tsdb/tsdb.php
@@ -43,9 +43,10 @@ function tsdb_init_plugin() {
     // Instantiate core services.
     $logger       = new TSDB\Logger();
     $rate_limiter = new TSDB\Rate_Limiter();
-    $api_client   = new TSDB\Api_Client( $logger, $rate_limiter );
-    $sync_manager = new TSDB\Sync_Manager( $api_client, $logger );
-    $rest_api     = new TSDB\Rest_API( $api_client );
+    $cache        = new TSDB\Cache_Store();
+    $api_client   = new TSDB\Api_Client( $logger, $rate_limiter, $cache );
+    $sync_manager = new TSDB\Sync_Manager( $api_client, $logger, $cache );
+    $rest_api     = new TSDB\Rest_API( $api_client, $cache );
     $admin_ui     = new TSDB\Admin_UI( $api_client, $sync_manager );
 
     // Boot services.


### PR DESCRIPTION
## Summary
- add Cache_Store class with object-cache fallback to database
- cache API client and REST responses with per-type TTLs
- purge caches via REST and on event updates

## Testing
- `php -l wp-tsdb/includes/cache-store.php`
- `php -l wp-tsdb/includes/api-client.php`
- `php -l wp-tsdb/includes/rest-api.php`
- `php -l wp-tsdb/includes/sync-manager.php`
- `php -l wp-tsdb/tsdb.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb8570615c8328a6a824fd7078a727