### PR TITLE
Add media importer and expose attachment URLs

### DIFF
--- a/wp-tsdb/includes/media-importer.php
+++ b/wp-tsdb/includes/media-importer.php
@@ -1,0 +1,91 @@
+<?php
+namespace TSDB;
+
+/**
+ * Helper for importing remote images into WordPress media library.
+ */
+class Media_Importer {
+    /**
+     * Download an image and create a WP attachment.
+     * Deduplicates by stored hash meta and cleans up replaced attachments.
+     *
+     * @param string $url Remote image URL.
+     * @param int    $existing_id Existing attachment ID to replace.
+     * @return int|null Attachment ID or null on failure.
+     */
+    public function import( $url, $existing_id = 0 ) {
+        if ( empty( $url ) ) {
+            if ( $existing_id ) {
+                wp_delete_attachment( $existing_id, true );
+            }
+            return null;
+        }
+        $tmp = download_url( $url );
+        if ( is_wp_error( $tmp ) ) {
+            return $existing_id ?: null;
+        }
+        $hash    = md5_file( $tmp );
+        $current = $this->find_by_hash( $hash );
+        if ( $current ) {
+            @unlink( $tmp );
+            if ( $existing_id && $existing_id != $current ) {
+                wp_delete_attachment( $existing_id, true );
+            }
+            return $current;
+        }
+        $file = [
+            'name'     => basename( parse_url( $url, PHP_URL_PATH ) ),
+            'tmp_name' => $tmp,
+        ];
+        $id = media_handle_sideload( $file, 0 );
+        if ( is_wp_error( $id ) ) {
+            @unlink( $tmp );
+            return $existing_id ?: null;
+        }
+        update_post_meta( $id, '_tsdb_hash', $hash );
+        $meta = wp_generate_attachment_metadata( $id, get_attached_file( $id ) );
+        wp_update_attachment_metadata( $id, $meta );
+        if ( $existing_id && $existing_id != $id ) {
+            wp_delete_attachment( $existing_id, true );
+        }
+        return $id;
+    }
+
+    protected function find_by_hash( $hash ) {
+        $posts = get_posts( [
+            'post_type'  => 'attachment',
+            'post_status'=> 'inherit',
+            'numberposts'=> 1,
+            'fields'     => 'ids',
+            'meta_key'   => '_tsdb_hash',
+            'meta_value' => $hash,
+        ] );
+        return $posts ? (int) $posts[0] : 0;
+    }
+
+    /**
+     * Remove attachments imported by TSDB that are no longer referenced.
+     */
+    public function cleanup_orphans() {
+        global $wpdb;
+        $ids = array_merge(
+            $wpdb->get_col( "SELECT logo_id FROM {$wpdb->prefix}tsdb_leagues WHERE logo_id IS NOT NULL" ),
+            $wpdb->get_col( "SELECT badge_id FROM {$wpdb->prefix}tsdb_teams WHERE badge_id IS NOT NULL" ),
+            $wpdb->get_col( "SELECT thumb_id FROM {$wpdb->prefix}tsdb_players WHERE thumb_id IS NOT NULL" ),
+            $wpdb->get_col( "SELECT image_id FROM {$wpdb->prefix}tsdb_venues WHERE image_id IS NOT NULL" )
+        );
+        $ids = array_map( 'intval', $ids );
+        $attachments = get_posts( [
+            'post_type'  => 'attachment',
+            'post_status'=> 'inherit',
+            'numberposts'=> -1,
+            'fields'     => 'ids',
+            'meta_key'   => '_tsdb_hash',
+        ] );
+        foreach ( $attachments as $att_id ) {
+            if ( ! in_array( $att_id, $ids, true ) ) {
+                wp_delete_attachment( $att_id, true );
+            }
+        }
+    }
+}

--- a/wp-tsdb/tsdb.php
+++ b/wp-tsdb/tsdb.php
@@ -29,7 +29,8 @@ spl_autoload_register( function ( $class ) {
     }
 
     $path = TSDB_PATH . 'includes/' . strtolower( str_replace( 'TSDB\\', '', $class ) );
-    $path = str_replace( '\\', '/', $path ) . '.php';
+    $path = str_replace( '\\', '/', $path );
+    $path = str_replace( '_', '-', $path ) . '.php';
 
     if ( file_exists( $path ) ) {
         include $path;
@@ -45,7 +46,8 @@ function tsdb_init_plugin() {
     $rate_limiter = new TSDB\Rate_Limiter();
     $cache        = new TSDB\Cache_Store();
     $api_client   = new TSDB\Api_Client( $logger, $rate_limiter, $cache );
-    $sync_manager = new TSDB\Sync_Manager( $api_client, $logger, $cache );
+    $media        = new TSDB\Media_Importer();
+    $sync_manager = new TSDB\Sync_Manager( $api_client, $logger, $cache, $media );
     $rest_api     = new TSDB\Rest_API( $api_client, $cache );
     $admin_ui     = new TSDB\Admin_UI( $api_client, $sync_manager );
 
@@ -74,6 +76,7 @@ function tsdb_activate() {
         country varchar(100) NOT NULL,
         name varchar(255) NOT NULL,
         season_current varchar(25) DEFAULT NULL,
+        logo_id bigint(20) unsigned DEFAULT NULL,
         logo_url text DEFAULT NULL,
         updated_at datetime DEFAULT CURRENT_TIMESTAMP,
         PRIMARY KEY (id),
@@ -97,6 +100,7 @@ function tsdb_activate() {
         name varchar(255) NOT NULL,
         short_name varchar(100) DEFAULT NULL,
         ext_id varchar(50) NOT NULL,
+        badge_id bigint(20) unsigned DEFAULT NULL,
         badge_url text DEFAULT NULL,
         venue_id bigint(20) unsigned DEFAULT NULL,
         country varchar(100) DEFAULT NULL,
@@ -113,6 +117,7 @@ function tsdb_activate() {
         name varchar(255) NOT NULL,
         pos varchar(10) DEFAULT NULL,
         ext_id varchar(50) NOT NULL,
+        thumb_id bigint(20) unsigned DEFAULT NULL,
         thumb_url text DEFAULT NULL,
         number varchar(20) DEFAULT NULL,
         nationality varchar(100) DEFAULT NULL,
@@ -129,6 +134,7 @@ function tsdb_activate() {
         city varchar(100) DEFAULT NULL,
         country varchar(100) DEFAULT NULL,
         ext_id varchar(50) NOT NULL,
+        image_id bigint(20) unsigned DEFAULT NULL,
         image_url text DEFAULT NULL,
         capacity int DEFAULT NULL,
         lat decimal(10,6) DEFAULT NULL,


### PR DESCRIPTION
## Summary
- Add Media_Importer helper to download and dedupe images via WP media API
- Store attachment IDs for leagues and teams and return URLs in REST endpoints
- Generate image sizes and remove unused attachments

## Testing
- `php -l wp-tsdb/tsdb.php`
- `php -l wp-tsdb/includes/media-importer.php`
- `php -l wp-tsdb/includes/sync-manager.php`
- `php -l wp-tsdb/includes/rest-api.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb878071608328a09e58286219c7b5