### PR TITLE
Add live fixtures block and shortcode

### DIFF
--- a/wp-tsdb/blocks/live-fixtures.js
+++ b/wp-tsdb/blocks/live-fixtures.js
@@ -1,0 +1,38 @@
+(function(){
+    const apiBase = (window.wpApiSettings ? window.wpApiSettings.root : '/wp-json/') + 'tsdb/v1/';
+
+    function renderFixtures(el, league, status){
+        const params = new URLSearchParams();
+        if(league){ params.append('league', league); }
+        if(status){ params.append('status', status); }
+        fetch(apiBase + 'fixtures?' + params.toString())
+            .then(r => r.json())
+            .then(data => {
+                el.innerHTML = '';
+                if(Array.isArray(data)){
+                    data.forEach(f => {
+                        const item = document.createElement('div');
+                        const hs = f.home_score !== null && f.home_score !== undefined ? f.home_score : '';
+                        const as = f.away_score !== null && f.away_score !== undefined ? f.away_score : '';
+                        item.textContent = `${f.home_id} ${hs} - ${as} ${f.away_id}`;
+                        el.appendChild(item);
+                    });
+                }
+            })
+            .catch(err => console.error('tsdb fixtures fetch failed', err));
+    }
+
+    function init(){
+        document.querySelectorAll('.tsdb-live-fixtures').forEach(el => {
+            const cfg = JSON.parse(el.dataset.tsdb || '{}');
+            const league = cfg.league || 0;
+            const status = cfg.status || 'live';
+            const poll = () => renderFixtures(el, league, status);
+            poll();
+            const interval = (status === 'live' || status === 'inplay') ? 20000 : 30000;
+            setInterval(poll, interval);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', init);
+})();

--- a/wp-tsdb/includes/blocks.php
+++ b/wp-tsdb/includes/blocks.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Block registrations for TSDB plugin.
+ */
+namespace TSDB;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register custom blocks and their scripts.
+ */
+function register_blocks() {
+    wp_register_script(
+        'tsdb-live-fixtures',
+        TSDB_URL . 'blocks/live-fixtures.js',
+        [],
+        TSDB_VERSION,
+        true
+    );
+
+    if ( function_exists( 'register_block_type' ) ) {
+        register_block_type( 'tsdb/live-fixtures', [
+            'editor_script' => 'tsdb-live-fixtures',
+            'script'        => 'tsdb-live-fixtures',
+            'render_callback' => __NAMESPACE__ . '\\render_live_fixtures_block',
+        ] );
+    }
+}
+add_action( 'init', __NAMESPACE__ . '\\register_blocks' );
+
+/**
+ * Server-side render callback for live fixtures block.
+ *
+ * @param array $attributes Block attributes.
+ * @return string HTML markup for block container.
+ */
+function render_live_fixtures_block( $attributes = [] ) {
+    $league = isset( $attributes['league'] ) ? intval( $attributes['league'] ) : 0;
+    $status = isset( $attributes['status'] ) ? sanitize_text_field( $attributes['status'] ) : 'live';
+    $data   = [
+        'league' => $league,
+        'status' => $status,
+    ];
+    return '<div class="tsdb-live-fixtures" data-tsdb="' . esc_attr( wp_json_encode( $data ) ) . '"></div>';
+}

--- a/wp-tsdb/includes/shortcodes.php
+++ b/wp-tsdb/includes/shortcodes.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Shortcode handlers for TSDB blocks.
+ */
+namespace TSDB;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register plugin shortcodes.
+ */
+function register_shortcodes() {
+    add_shortcode( 'tsdb_live_fixtures', __NAMESPACE__ . '\\shortcode_live_fixtures' );
+}
+add_action( 'init', __NAMESPACE__ . '\\register_shortcodes' );
+
+/**
+ * Render live fixtures via shortcode.
+ *
+ * Usage: [tsdb_live_fixtures league="123" status="live"]
+ *
+ * @param array $atts Shortcode attributes.
+ * @return string
+ */
+function shortcode_live_fixtures( $atts ) {
+    $atts = shortcode_atts(
+        [
+            'league' => 0,
+            'status' => 'live',
+        ],
+        $atts,
+        'tsdb_live_fixtures'
+    );
+    wp_enqueue_script( 'tsdb-live-fixtures' );
+    return '<div class="tsdb-live-fixtures" data-tsdb="' . esc_attr( wp_json_encode( $atts ) ) . '"></div>';
+}

--- a/wp-tsdb/tsdb.php
+++ b/wp-tsdb/tsdb.php
@@ -36,6 +36,10 @@ spl_autoload_register( function ( $class ) {
     }
 } );
 
+// Load procedural includes.
+require_once TSDB_PATH . 'includes/blocks.php';
+require_once TSDB_PATH . 'includes/shortcodes.php';
+
 /**
  * Initialize plugin services.
  */


### PR DESCRIPTION
## Summary
- register procedural block and shortcode includes
- add live fixtures block script and registration
- provide shortcode handler that enqueues block script

## Testing
- `php -l wp-tsdb/includes/blocks.php`
- `php -l wp-tsdb/includes/shortcodes.php`
- `php -l wp-tsdb/tsdb.php`
- `node --check wp-tsdb/blocks/live-fixtures.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb878c6cb08328b9d0e133a9b75cae