### PR TITLE
Handle rate limit persistence and API retries

### DIFF
--- a/wp-tsdb/includes/rate-limiter.php
+++ b/wp-tsdb/includes/rate-limiter.php
@@ -2,19 +2,53 @@
 namespace TSDB;
 
 /**
- * Simple token bucket rate limiter stored in transients.
+ * Simple token bucket rate limiter.
+ *
+ * Persists token count and next available timestamp so that consumers can
+ * determine when they may resume API requests.
  */
 class Rate_Limiter {
     protected $limit_per_min = 90; // tokens per minute
-    protected $bucket_key    = 'tsdb_tokens';
+    protected $option_key    = 'tsdb_rate_limit';
 
+    /**
+     * Attempt to consume a single token.
+     *
+     * @return bool Whether a token was consumed.
+     */
     public function allow() {
-        $tokens = get_transient( $this->bucket_key );
-        $tokens = false === $tokens ? $this->limit_per_min : (int) $tokens;
-        if ( $tokens <= 0 ) {
+        $now  = time();
+        $data = get_option(
+            $this->option_key,
+            [ 'tokens' => $this->limit_per_min, 'next' => $now + MINUTE_IN_SECONDS ]
+        );
+
+        if ( $now >= (int) $data['next'] ) {
+            // Bucket has refreshed.
+            $data['tokens'] = $this->limit_per_min;
+            $data['next']   = $now + MINUTE_IN_SECONDS;
+        }
+
+        if ( $data['tokens'] <= 0 ) {
+            update_option( $this->option_key, $data );
             return false;
         }
-        set_transient( $this->bucket_key, $tokens - 1, MINUTE_IN_SECONDS );
+
+        $data['tokens']--;
+        update_option( $this->option_key, $data );
         return true;
+    }
+
+    /**
+     * Retrieve the timestamp when a new token bucket will become available.
+     *
+     * @return int Unix timestamp.
+     */
+    public function next_available() {
+        $data = get_option(
+            $this->option_key,
+            [ 'tokens' => $this->limit_per_min, 'next' => time() ]
+        );
+        return (int) $data['next'];
     }
 }


### PR DESCRIPTION
## Summary
- Persist rate-limit tokens with a next-available timestamp
- Add exponential backoff retry (15s→30s→60s) for API requests
- Requeue league sync jobs when rate limit is hit

## Testing
- `php -l wp-tsdb/includes/rate-limiter.php`
- `php -l wp-tsdb/includes/api-client.php`
- `php -l wp-tsdb/includes/sync-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb878dc820832880643e0a932368da