### PR TITLE
Add live event block and shortcode

### DIFF
--- a/wp-tsdb/blocks/live-event.js
+++ b/wp-tsdb/blocks/live-event.js
@@ -1,0 +1,30 @@
+(function(){
+    const apiBase = (window.wpApiSettings ? window.wpApiSettings.root : '/wp-json/') + 'tsdb/v1/';
+
+    function renderEvent(el, eventId){
+        fetch(apiBase + 'event/' + eventId)
+            .then(r => r.json())
+            .then(data => {
+                if(!data){ return; }
+                const hs = data.home_score !== null && data.home_score !== undefined ? data.home_score : '';
+                const as = data.away_score !== null && data.away_score !== undefined ? data.away_score : '';
+                el.textContent = `${data.home_id} ${hs} - ${as} ${data.away_id}`;
+            })
+            .catch(err => console.error('tsdb event fetch failed', err));
+    }
+
+    function init(){
+        document.querySelectorAll('.tsdb-live-event').forEach(el => {
+            const cfg = JSON.parse(el.dataset.tsdb || '{}');
+            const eventId = cfg.event || cfg.id || 0;
+            const status = cfg.status || 'live';
+            if(!eventId){ return; }
+            const poll = () => renderEvent(el, eventId);
+            poll();
+            const interval = (status === 'live' || status === 'inplay') ? 20000 : 30000;
+            setInterval(poll, interval);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', init);
+})();

--- a/wp-tsdb/includes/blocks.php
+++ b/wp-tsdb/includes/blocks.php
@@ -20,11 +20,25 @@ function register_blocks() {
         true
     );
 
+    wp_register_script(
+        'tsdb-live-event',
+        TSDB_URL . 'blocks/live-event.js',
+        [],
+        TSDB_VERSION,
+        true
+    );
+
     if ( function_exists( 'register_block_type' ) ) {
         register_block_type( 'tsdb/live-fixtures', [
             'editor_script' => 'tsdb-live-fixtures',
             'script'        => 'tsdb-live-fixtures',
             'render_callback' => __NAMESPACE__ . '\\render_live_fixtures_block',
+        ] );
+
+        register_block_type( 'tsdb/live-event', [
+            'editor_script' => 'tsdb-live-event',
+            'script'        => 'tsdb-live-event',
+            'render_callback' => __NAMESPACE__ . '\\render_live_event_block',
         ] );
     }
 }
@@ -44,4 +58,20 @@ function render_live_fixtures_block( $attributes = [] ) {
         'status' => $status,
     ];
     return '<div class="tsdb-live-fixtures" data-tsdb="' . esc_attr( wp_json_encode( $data ) ) . '"></div>';
+}
+
+/**
+ * Server-side render callback for live event block.
+ *
+ * @param array $attributes Block attributes.
+ * @return string HTML markup for block container.
+ */
+function render_live_event_block( $attributes = [] ) {
+    $event  = isset( $attributes['event'] ) ? intval( $attributes['event'] ) : 0;
+    $status = isset( $attributes['status'] ) ? sanitize_text_field( $attributes['status'] ) : 'live';
+    $data   = [
+        'event'  => $event,
+        'status' => $status,
+    ];
+    return '<div class="tsdb-live-event" data-tsdb="' . esc_attr( wp_json_encode( $data ) ) . '"></div>';
 }

--- a/wp-tsdb/includes/shortcodes.php
+++ b/wp-tsdb/includes/shortcodes.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function register_shortcodes() {
     add_shortcode( 'tsdb_live_fixtures', __NAMESPACE__ . '\\shortcode_live_fixtures' );
+    add_shortcode( 'tsdb_live_event', __NAMESPACE__ . '\\shortcode_live_event' );
 }
 add_action( 'init', __NAMESPACE__ . '\\register_shortcodes' );
 
@@ -35,4 +36,25 @@ function shortcode_live_fixtures( $atts ) {
     );
     wp_enqueue_script( 'tsdb-live-fixtures' );
     return '<div class="tsdb-live-fixtures" data-tsdb="' . esc_attr( wp_json_encode( $atts ) ) . '"></div>';
+}
+
+/**
+ * Render live event via shortcode.
+ *
+ * Usage: [tsdb_live_event event="123" status="live"]
+ *
+ * @param array $atts Shortcode attributes.
+ * @return string
+ */
+function shortcode_live_event( $atts ) {
+    $atts = shortcode_atts(
+        [
+            'event'  => 0,
+            'status' => 'live',
+        ],
+        $atts,
+        'tsdb_live_event'
+    );
+    wp_enqueue_script( 'tsdb-live-event' );
+    return '<div class="tsdb-live-event" data-tsdb="' . esc_attr( wp_json_encode( $atts ) ) . '"></div>';
 }


### PR DESCRIPTION
## Summary
- add Live Event block script with REST polling
- register block and shortcode for live events

## Testing
- `php -l includes/blocks.php`
- `php -l includes/shortcodes.php`
- `node --check blocks/live-event.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68bb8a16c7a88328a6bbe52bab3a2bbe