### PR TITLE
docs: document REST route registration

### DIFF
--- a/wp-tsdb/includes/rest-api.php
+++ b/wp-tsdb/includes/rest-api.php
@@ -23,6 +23,11 @@ class Rest_API {
         $this->cache = $cache;
     }
 
+    /**
+     * Register all REST API routes for the plugin.
+     *
+     * @return void
+     */
     public function register_routes() {
         add_action( 'rest_api_init', function () {
             register_rest_route( 'tsdb/v1', '/leagues', [


### PR DESCRIPTION
## Summary
- add docblock describing REST API route registration

## Testing
- `php -l wp-tsdb/includes/rest-api.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb8a1460e0832881536c56e6598896