### PR TITLE
Implement cache store and invalidation hooks

### DIFF
--- a/wp-tsdb/includes/sync-manager.php
+++ b/wp-tsdb/includes/sync-manager.php
@@ -363,6 +363,11 @@ class Sync_Manager {
                 ],
                 [ '%d','%d','%d','%d','%d','%s','%s','%s','%d','%d','%s','%s' ]
             );
+
+            if ( ! empty( $row['idEvent'] ) ) {
+                $this->cache->delete( 'event_' . $row['idEvent'] );
+            }
+
             $count++;
         }
         if ( $count ) {
@@ -370,6 +375,8 @@ class Sync_Manager {
             $this->cache->delete( 'fixtures_' . $league_id . '_live' );
             $this->cache->delete( 'fixtures_' . $league_id . '_inplay' );
             $this->cache->delete( 'fixtures_' . $league_id . '_finished' );
+            $this->cache->delete( 'live_' . $league_id );
+            $this->cache->delete( 'live_all' );
         }
         return $count;
     }


### PR DESCRIPTION
## Summary
- add persistent Cache_Store with object cache fallback
- wire Cache_Store through API client and REST layer with TTLs
- invalidate cached fixtures, live feeds, and event details when events update; add manual purge endpoint

## Testing
- `php -l wp-tsdb/includes/cache-store.php`
- `php -l wp-tsdb/includes/sync-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb8a111874832895289a6617cc50fd