### PR TITLE
Expose team badges on live fixtures

### DIFF
--- a/wp-tsdb/includes/rest-api.php
+++ b/wp-tsdb/includes/rest-api.php
@@ -268,6 +268,26 @@ class Rest_API {
             $rows = $wpdb->get_results( $sql );
             $this->cache->set( $cache_key, $rows, self::TTL_FIXTURE_LIVE );
         }
+        $team_ids = [];
+        foreach ( $rows as $row ) {
+            $team_ids[] = $row->home_id;
+            $team_ids[] = $row->away_id;
+        }
+        $team_ids = array_unique( array_map( 'intval', $team_ids ) );
+        $badges   = [];
+        if ( $team_ids ) {
+            $placeholders = implode( ',', array_fill( 0, count( $team_ids ), '%d' ) );
+            $team_table   = $wpdb->prefix . 'tsdb_teams';
+            $sql          = $wpdb->prepare( "SELECT id, badge_id FROM {$team_table} WHERE id IN ($placeholders)", $team_ids );
+            $results      = $wpdb->get_results( $sql );
+            foreach ( $results as $r ) {
+                $badges[ $r->id ] = $r->badge_id;
+            }
+        }
+        foreach ( $rows as $row ) {
+            $row->home_badge = isset( $badges[ $row->home_id ] ) && $badges[ $row->home_id ] ? wp_get_attachment_url( $badges[ $row->home_id ] ) : null;
+            $row->away_badge = isset( $badges[ $row->away_id ] ) && $badges[ $row->away_id ] ? wp_get_attachment_url( $badges[ $row->away_id ] ) : null;
+        }
         return $this->etag_response( $request, $rows );
     }
 


### PR DESCRIPTION
## Summary
- Download and manage remote images via new Media_Importer class
- Serve home and away team badge URLs in live fixture responses
- Clean up unused attachments to keep the media library tidy

## Testing
- `php -l includes/rest-api.php`
- `php -l includes/media-importer.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb8d8c548c832888e63d104c3edc66