### PR TITLE
Improve error handling for sync routines

### DIFF
--- a/wp-tsdb/includes/admin-ui.php
+++ b/wp-tsdb/includes/admin-ui.php
@@ -62,8 +62,14 @@ class Admin_UI {
         check_ajax_referer( 'tsdb_sync' );
         $league = sanitize_text_field( $_POST['league'] ?? '' );
         $season = sanitize_text_field( $_POST['season'] ?? '' );
-        $this->sync_manager->sync_seasons( $league );
-        $this->sync_manager->sync_teams( $league );
+        $result = $this->sync_manager->sync_seasons( $league );
+        if ( is_wp_error( $result ) ) {
+            wp_send_json_error( $result->get_error_message() );
+        }
+        $result = $this->sync_manager->sync_teams( $league );
+        if ( is_wp_error( $result ) ) {
+            wp_send_json_error( $result->get_error_message() );
+        }
         $count = $this->sync_manager->sync_events( $league, $season );
         if ( is_wp_error( $count ) ) {
             wp_send_json_error( $count->get_error_message() );

--- a/wp-tsdb/includes/cli.php
+++ b/wp-tsdb/includes/cli.php
@@ -37,8 +37,14 @@ class CLI {
      */
     public function seed( $args, $assoc_args ) {
         list( $league, $season ) = $args;
-        $this->sync_manager->sync_seasons( $league );
-        $this->sync_manager->sync_teams( $league );
+        $result = $this->sync_manager->sync_seasons( $league );
+        if ( is_wp_error( $result ) ) {
+            \WP_CLI::error( $result->get_error_message() );
+        }
+        $result = $this->sync_manager->sync_teams( $league );
+        if ( is_wp_error( $result ) ) {
+            \WP_CLI::error( $result->get_error_message() );
+        }
         $count = $this->sync_manager->sync_events( $league, $season );
         if ( is_wp_error( $count ) ) {
             \WP_CLI::error( $count->get_error_message() );

--- a/wp-tsdb/includes/sync-manager.php
+++ b/wp-tsdb/includes/sync-manager.php
@@ -153,14 +153,18 @@ class Sync_Manager {
     public function run_league_sync( $league_ext_id ) {
         // Refresh seasons and teams before syncing events.
         $result = $this->sync_seasons( $league_ext_id );
-        if ( is_wp_error( $result ) && 'tsdb_rate_limited' === $result->get_error_code() ) {
-            $this->requeue_sync( $league_ext_id );
+        if ( is_wp_error( $result ) ) {
+            if ( 'tsdb_rate_limited' === $result->get_error_code() ) {
+                $this->requeue_sync( $league_ext_id );
+            }
             return;
         }
 
         $result = $this->sync_teams( $league_ext_id );
-        if ( is_wp_error( $result ) && 'tsdb_rate_limited' === $result->get_error_code() ) {
-            $this->requeue_sync( $league_ext_id );
+        if ( is_wp_error( $result ) ) {
+            if ( 'tsdb_rate_limited' === $result->get_error_code() ) {
+                $this->requeue_sync( $league_ext_id );
+            }
             return;
         }
 
@@ -171,8 +175,10 @@ class Sync_Manager {
         ) );
         if ( $season ) {
             $result = $this->sync_events( $league_ext_id, $season );
-            if ( is_wp_error( $result ) && 'tsdb_rate_limited' === $result->get_error_code() ) {
-                $this->requeue_sync( $league_ext_id );
+            if ( is_wp_error( $result ) ) {
+                if ( 'tsdb_rate_limited' === $result->get_error_code() ) {
+                    $this->requeue_sync( $league_ext_id );
+                }
                 return;
             }
         }


### PR DESCRIPTION
## Summary
- return early from `run_league_sync` when sync methods fail and requeue on rate limits
- surface sync errors in admin seed and CLI commands

## Testing
- `php -l wp-tsdb/includes/sync-manager.php`
- `php -l wp-tsdb/includes/admin-ui.php`
- `php -l wp-tsdb/includes/cli.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb8d8135f083289f4405dfec28d716