### PR TITLE
Invalidate standings cache when events update

### DIFF
--- a/wp-tsdb/includes/sync-manager.php
+++ b/wp-tsdb/includes/sync-manager.php
@@ -388,6 +388,9 @@ class Sync_Manager {
             $this->cache->delete( 'fixtures_' . $league_id . '_finished' );
             $this->cache->delete( 'live_' . $league_id );
             $this->cache->delete( 'live_all' );
+            // League standings depend on finished events.
+            // Purge cached standings so they can be recalculated on next request.
+            $this->cache->delete( 'standings_' . $league_ext_id . '_' . $season );
         }
         return $count;
     }


### PR DESCRIPTION
## Summary
- ensure league standings caches are purged when event data changes

## Testing
- `php -l wp-tsdb/includes/sync-manager.php`
- `php -l wp-tsdb/includes/cache-store.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb8d88fac48328b15222b307413b62