### PR TITLE
Add live standings block and shortcode with polling

### DIFF
--- a/wp-tsdb/blocks/live-standings.js
+++ b/wp-tsdb/blocks/live-standings.js
@@ -1,0 +1,39 @@
+(function(){
+    const apiBase = (window.wpApiSettings ? window.wpApiSettings.root : '/wp-json/') + 'tsdb/v1/';
+
+    function renderStandings(el, league, season){
+        const params = new URLSearchParams();
+        if(league){ params.append('league', league); }
+        if(season){ params.append('season', season); }
+        fetch(apiBase + 'standings?' + params.toString())
+            .then(r => r.json())
+            .then(data => {
+                el.innerHTML = '';
+                if(Array.isArray(data)){
+                    data.forEach(t => {
+                        const item = document.createElement('div');
+                        const name = t.name || t.team || t.teamname || t.strTeam || t.teamid || '';
+                        const pts = (t.points !== undefined ? t.points : (t.P !== undefined ? t.P : ''));
+                        item.textContent = name + (pts !== '' ? ' (' + pts + ')' : '');
+                        el.appendChild(item);
+                    });
+                }
+            })
+            .catch(err => console.error('tsdb standings fetch failed', err));
+    }
+
+    function init(){
+        document.querySelectorAll('.tsdb-live-standings').forEach(el => {
+            const cfg = JSON.parse(el.dataset.tsdb || '{}');
+            const league = cfg.league || 0;
+            const season = cfg.season || '';
+            const status = cfg.status || 'live';
+            const poll = () => renderStandings(el, league, season);
+            poll();
+            const interval = (status === 'live' || status === 'inplay') ? 20000 : 30000;
+            setInterval(poll, interval);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', init);
+})();

--- a/wp-tsdb/includes/blocks.php
+++ b/wp-tsdb/includes/blocks.php
@@ -28,6 +28,14 @@ function register_blocks() {
         true
     );
 
+    wp_register_script(
+        'tsdb-live-standings',
+        TSDB_URL . 'blocks/live-standings.js',
+        [],
+        TSDB_VERSION,
+        true
+    );
+
     if ( function_exists( 'register_block_type' ) ) {
         register_block_type( 'tsdb/live-fixtures', [
             'editor_script' => 'tsdb-live-fixtures',
@@ -39,6 +47,12 @@ function register_blocks() {
             'editor_script' => 'tsdb-live-event',
             'script'        => 'tsdb-live-event',
             'render_callback' => __NAMESPACE__ . '\\render_live_event_block',
+        ] );
+
+        register_block_type( 'tsdb/live-standings', [
+            'editor_script' => 'tsdb-live-standings',
+            'script'        => 'tsdb-live-standings',
+            'render_callback' => __NAMESPACE__ . '\\render_live_standings_block',
         ] );
     }
 }
@@ -74,4 +88,22 @@ function render_live_event_block( $attributes = [] ) {
         'status' => $status,
     ];
     return '<div class="tsdb-live-event" data-tsdb="' . esc_attr( wp_json_encode( $data ) ) . '"></div>';
+}
+
+/**
+ * Server-side render callback for live standings block.
+ *
+ * @param array $attributes Block attributes.
+ * @return string HTML markup for block container.
+ */
+function render_live_standings_block( $attributes = [] ) {
+    $league = isset( $attributes['league'] ) ? intval( $attributes['league'] ) : 0;
+    $season = isset( $attributes['season'] ) ? sanitize_text_field( $attributes['season'] ) : '';
+    $status = isset( $attributes['status'] ) ? sanitize_text_field( $attributes['status'] ) : 'live';
+    $data   = [
+        'league' => $league,
+        'season' => $season,
+        'status' => $status,
+    ];
+    return '<div class="tsdb-live-standings" data-tsdb="' . esc_attr( wp_json_encode( $data ) ) . '"></div>';
 }

--- a/wp-tsdb/includes/shortcodes.php
+++ b/wp-tsdb/includes/shortcodes.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function register_shortcodes() {
     add_shortcode( 'tsdb_live_fixtures', __NAMESPACE__ . '\\shortcode_live_fixtures' );
     add_shortcode( 'tsdb_live_event', __NAMESPACE__ . '\\shortcode_live_event' );
+    add_shortcode( 'tsdb_live_standings', __NAMESPACE__ . '\\shortcode_live_standings' );
 }
 add_action( 'init', __NAMESPACE__ . '\\register_shortcodes' );
 
@@ -57,4 +58,26 @@ function shortcode_live_event( $atts ) {
     );
     wp_enqueue_script( 'tsdb-live-event' );
     return '<div class="tsdb-live-event" data-tsdb="' . esc_attr( wp_json_encode( $atts ) ) . '"></div>';
+}
+
+/**
+ * Render league standings via shortcode.
+ *
+ * Usage: [tsdb_live_standings league="123" season="2023" status="live"]
+ *
+ * @param array $atts Shortcode attributes.
+ * @return string
+ */
+function shortcode_live_standings( $atts ) {
+    $atts = shortcode_atts(
+        [
+            'league' => 0,
+            'season' => '',
+            'status' => 'live',
+        ],
+        $atts,
+        'tsdb_live_standings'
+    );
+    wp_enqueue_script( 'tsdb-live-standings' );
+    return '<div class="tsdb-live-standings" data-tsdb="' . esc_attr( wp_json_encode( $atts ) ) . '"></div>';
 }


### PR DESCRIPTION
## Summary
- Add front-end script for rendering league standings and polling the TSDB REST API.
- Register new `tsdb/live-standings` block and shortcode to output standings containers.
- Provide server-side rendering callback and shortcode handler.

## Testing
- `php -l wp-tsdb/includes/blocks.php`
- `php -l wp-tsdb/includes/shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb8d934120832881d2818c3c1cf924