### PR TITLE
Implement WP-CLI commands with logging and expose admin log/health pages

### DIFF
--- a/wp-tsdb/includes/cli.php
+++ b/wp-tsdb/includes/cli.php
@@ -7,10 +7,12 @@ namespace TSDB;
 class CLI {
     protected $sync_manager;
     protected $cache;
+    protected $logger;
 
-    public function __construct( Sync_Manager $sync_manager, Cache_Store $cache ) {
+    public function __construct( Sync_Manager $sync_manager, Cache_Store $cache, Logger $logger ) {
         $this->sync_manager = $sync_manager;
         $this->cache        = $cache;
+        $this->logger       = $logger;
     }
 
     /**
@@ -43,6 +45,7 @@ class CLI {
         if ( is_wp_error( $count ) ) {
             \WP_CLI::error( $count->get_error_message() );
         }
+        $this->logger->info( 'cli', 'Seeded league', [ 'league' => $league, 'season' => $season, 'events' => $count ] );
         \WP_CLI::success( sprintf( '%d events seeded', $count ) );
     }
 
@@ -51,6 +54,7 @@ class CLI {
      */
     public function live( $args, $assoc_args ) {
         $this->sync_manager->cron_tick();
+        $this->logger->info( 'cli', 'Live sync triggered' );
         \WP_CLI::success( 'Live sync triggered' );
     }
 
@@ -61,6 +65,7 @@ class CLI {
         $this->cache->flush();
         global $wpdb;
         $wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}tsdb_logs" );
+        $this->logger->info( 'cli', 'Cache and logs purged' );
         \WP_CLI::success( 'Cache and logs purged' );
     }
 }

--- a/wp-tsdb/tsdb.php
+++ b/wp-tsdb/tsdb.php
@@ -54,7 +54,7 @@ function tsdb_init_plugin() {
     $sync_manager = new TSDB\Sync_Manager( $api_client, $logger, $cache, $media );
     $rest_api     = new TSDB\Rest_API( $api_client, $cache );
     $admin_ui     = new TSDB\Admin_UI( $api_client, $sync_manager, $logger );
-    $cli          = new TSDB\CLI( $sync_manager, $cache );
+    $cli          = new TSDB\CLI( $sync_manager, $cache, $logger );
 
     // Boot services.
     $rest_api->register_routes();


### PR DESCRIPTION
## Summary
- wire CLI commands to structured logger
- instantiate CLI with logger for consistent logging

## Testing
- `php -l wp-tsdb/includes/cli.php`
- `php -l wp-tsdb/tsdb.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb8d974c388328ae3de162bd0381a1