### PR TITLE
Add admin maintenance controls for cache, logs, and data reset

### DIFF
--- a/wp-tsdb/assets/admin.js
+++ b/wp-tsdb/assets/admin.js
@@ -102,5 +102,33 @@
                 alert(resp.data ? resp.data.message : 'Done');
             });
         });
+        $('#tsdb_clear_cache_btn').on('click', function(e){
+            e.preventDefault();
+            $.post(ajaxurl, {
+                action: 'tsdb_clear_cache',
+                _ajax_nonce: tsdbAdmin.nonce
+            }, function(resp){
+                alert(resp.data ? resp.data.message : 'Done');
+            });
+        });
+        $('#tsdb_clear_logs_btn').on('click', function(e){
+            e.preventDefault();
+            $.post(ajaxurl, {
+                action: 'tsdb_clear_logs',
+                _ajax_nonce: tsdbAdmin.nonce
+            }, function(resp){
+                alert(resp.data ? resp.data.message : 'Done');
+            });
+        });
+        $('#tsdb_delete_all_btn').on('click', function(e){
+            e.preventDefault();
+            if(!confirm('Are you sure?')){ return; }
+            $.post(ajaxurl, {
+                action: 'tsdb_delete_all_data',
+                _ajax_nonce: tsdbAdmin.nonce
+            }, function(resp){
+                alert(resp.data ? resp.data.message : 'Done');
+            });
+        });
     });
 })(jQuery);


### PR DESCRIPTION
## Summary
- Add maintenance buttons to settings for clearing cache, logs, or deleting all plugin data
- Implement AJAX handlers to flush cache, truncate logs, and drop/recreate TSDB tables
- Wire admin JS to trigger new actions with nonce checks and user alerts

## Testing
- `php -l wp-tsdb/includes/admin-ui.php`
- `node --check wp-tsdb/assets/admin.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68bb926f76788328b8426a1ea3c4c8d7