### PR TITLE
Add widgets for team, player, standings, H2H and TV schedule

### DIFF
--- a/wp-tsdb/blocks/h2h.js
+++ b/wp-tsdb/blocks/h2h.js
@@ -1,0 +1,38 @@
+(function(){
+    const apiBase = (window.wpApiSettings ? window.wpApiSettings.root : '/wp-json/') + 'tsdb/v1/';
+
+    function renderH2H(el, team1, team2){
+        const params = new URLSearchParams();
+        if(team1){ params.append('team1', team1); }
+        if(team2){ params.append('team2', team2); }
+        fetch(apiBase + 'h2h?' + params.toString())
+            .then(r => r.json())
+            .then(data => {
+                el.innerHTML = '';
+                if(data && data.summary){
+                    const s1 = data.summary[team1] || {};
+                    const s2 = data.summary[team2] || {};
+                    const div = document.createElement('div');
+                    div.textContent = `${s1.wins||0}-${s1.draws||0}-${s1.losses||0} vs ${s2.wins||0}-${s2.draws||0}-${s2.losses||0}`;
+                    el.appendChild(div);
+                }
+            })
+            .catch(err => console.error('tsdb h2h fetch failed', err));
+    }
+
+    function init(){
+        document.querySelectorAll('.tsdb-h2h').forEach(el => {
+            const cfg = JSON.parse(el.dataset.tsdb || '{}');
+            const team1 = cfg.team1 || 0;
+            const team2 = cfg.team2 || 0;
+            const status = cfg.status || 'live';
+            if(!team1 || !team2){ return; }
+            const poll = () => renderH2H(el, team1, team2);
+            poll();
+            const interval = (status === 'live' || status === 'inplay') ? 20000 : 30000;
+            setInterval(poll, interval);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', init);
+})();

--- a/wp-tsdb/blocks/league-table.js
+++ b/wp-tsdb/blocks/league-table.js
@@ -1,0 +1,39 @@
+(function(){
+    const apiBase = (window.wpApiSettings ? window.wpApiSettings.root : '/wp-json/') + 'tsdb/v1/';
+
+    function renderTable(el, league, season){
+        const params = new URLSearchParams();
+        if(league){ params.append('league', league); }
+        if(season){ params.append('season', season); }
+        fetch(apiBase + 'standings?' + params.toString())
+            .then(r => r.json())
+            .then(data => {
+                el.innerHTML = '';
+                if(Array.isArray(data)){
+                    data.forEach(t => {
+                        const item = document.createElement('div');
+                        const name = t.name || t.team || t.teamname || t.strTeam || t.teamid || '';
+                        const pts = (t.points !== undefined ? t.points : (t.P !== undefined ? t.P : ''));
+                        item.textContent = name + (pts !== '' ? ' (' + pts + ')' : '');
+                        el.appendChild(item);
+                    });
+                }
+            })
+            .catch(err => console.error('tsdb standings fetch failed', err));
+    }
+
+    function init(){
+        document.querySelectorAll('.tsdb-league-table').forEach(el => {
+            const cfg = JSON.parse(el.dataset.tsdb || '{}');
+            const league = cfg.league || 0;
+            const season = cfg.season || '';
+            const status = cfg.status || 'live';
+            const poll = () => renderTable(el, league, season);
+            poll();
+            const interval = (status === 'live' || status === 'inplay') ? 20000 : 30000;
+            setInterval(poll, interval);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', init);
+})();

--- a/wp-tsdb/blocks/player.js
+++ b/wp-tsdb/blocks/player.js
@@ -1,0 +1,29 @@
+(function(){
+    const apiBase = (window.wpApiSettings ? window.wpApiSettings.root : '/wp-json/') + 'tsdb/v1/';
+
+    function renderPlayer(el, id){
+        fetch(apiBase + 'player/' + id)
+            .then(r => r.json())
+            .then(data => {
+                if(!data){ return; }
+                const name = data.strPlayer || data.player || data.name || '';
+                el.textContent = name;
+            })
+            .catch(err => console.error('tsdb player fetch failed', err));
+    }
+
+    function init(){
+        document.querySelectorAll('.tsdb-player').forEach(el => {
+            const cfg = JSON.parse(el.dataset.tsdb || '{}');
+            const id = cfg.player || cfg.id || 0;
+            const status = cfg.status || 'live';
+            if(!id){ return; }
+            const poll = () => renderPlayer(el, id);
+            poll();
+            const interval = (status === 'live' || status === 'inplay') ? 20000 : 30000;
+            setInterval(poll, interval);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', init);
+})();

--- a/wp-tsdb/blocks/team.js
+++ b/wp-tsdb/blocks/team.js
@@ -1,0 +1,29 @@
+(function(){
+    const apiBase = (window.wpApiSettings ? window.wpApiSettings.root : '/wp-json/') + 'tsdb/v1/';
+
+    function renderTeam(el, id){
+        fetch(apiBase + 'team/' + id)
+            .then(r => r.json())
+            .then(data => {
+                if(!data){ return; }
+                const name = data.strTeam || data.team || data.name || '';
+                el.textContent = name;
+            })
+            .catch(err => console.error('tsdb team fetch failed', err));
+    }
+
+    function init(){
+        document.querySelectorAll('.tsdb-team').forEach(el => {
+            const cfg = JSON.parse(el.dataset.tsdb || '{}');
+            const id = cfg.team || cfg.id || 0;
+            const status = cfg.status || 'live';
+            if(!id){ return; }
+            const poll = () => renderTeam(el, id);
+            poll();
+            const interval = (status === 'live' || status === 'inplay') ? 20000 : 30000;
+            setInterval(poll, interval);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', init);
+})();

--- a/wp-tsdb/blocks/tv-schedule.js
+++ b/wp-tsdb/blocks/tv-schedule.js
@@ -1,0 +1,37 @@
+(function(){
+    const apiBase = (window.wpApiSettings ? window.wpApiSettings.root : '/wp-json/') + 'tsdb/v1/';
+
+    function renderTV(el, country){
+        const params = new URLSearchParams();
+        if(country){ params.append('country', country); }
+        fetch(apiBase + 'tv?' + params.toString())
+            .then(r => r.json())
+            .then(data => {
+                el.innerHTML = '';
+                if(Array.isArray(data)){
+                    data.forEach(item => {
+                        const div = document.createElement('div');
+                        const channel = item.channel || '';
+                        const name = item.event || item.name || '';
+                        div.textContent = channel + (name ? ': ' + name : '');
+                        el.appendChild(div);
+                    });
+                }
+            })
+            .catch(err => console.error('tsdb tv fetch failed', err));
+    }
+
+    function init(){
+        document.querySelectorAll('.tsdb-tv-schedule').forEach(el => {
+            const cfg = JSON.parse(el.dataset.tsdb || '{}');
+            const country = cfg.country || '';
+            const status = cfg.status || 'live';
+            const poll = () => renderTV(el, country);
+            poll();
+            const interval = (status === 'live' || status === 'inplay') ? 20000 : 30000;
+            setInterval(poll, interval);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', init);
+})();

--- a/wp-tsdb/includes/blocks.php
+++ b/wp-tsdb/includes/blocks.php
@@ -36,6 +36,46 @@ function register_blocks() {
         true
     );
 
+    wp_register_script(
+        'tsdb-team',
+        TSDB_URL . 'blocks/team.js',
+        [],
+        TSDB_VERSION,
+        true
+    );
+
+    wp_register_script(
+        'tsdb-player',
+        TSDB_URL . 'blocks/player.js',
+        [],
+        TSDB_VERSION,
+        true
+    );
+
+    wp_register_script(
+        'tsdb-league-table',
+        TSDB_URL . 'blocks/league-table.js',
+        [],
+        TSDB_VERSION,
+        true
+    );
+
+    wp_register_script(
+        'tsdb-h2h',
+        TSDB_URL . 'blocks/h2h.js',
+        [],
+        TSDB_VERSION,
+        true
+    );
+
+    wp_register_script(
+        'tsdb-tv-schedule',
+        TSDB_URL . 'blocks/tv-schedule.js',
+        [],
+        TSDB_VERSION,
+        true
+    );
+
     if ( function_exists( 'register_block_type' ) ) {
         register_block_type( 'tsdb/live-fixtures', [
             'editor_script' => 'tsdb-live-fixtures',
@@ -53,6 +93,36 @@ function register_blocks() {
             'editor_script' => 'tsdb-live-standings',
             'script'        => 'tsdb-live-standings',
             'render_callback' => __NAMESPACE__ . '\\render_live_standings_block',
+        ] );
+
+        register_block_type( 'tsdb/team', [
+            'editor_script' => 'tsdb-team',
+            'script'        => 'tsdb-team',
+            'render_callback' => __NAMESPACE__ . '\\render_team_block',
+        ] );
+
+        register_block_type( 'tsdb/player', [
+            'editor_script' => 'tsdb-player',
+            'script'        => 'tsdb-player',
+            'render_callback' => __NAMESPACE__ . '\\render_player_block',
+        ] );
+
+        register_block_type( 'tsdb/league-table', [
+            'editor_script' => 'tsdb-league-table',
+            'script'        => 'tsdb-league-table',
+            'render_callback' => __NAMESPACE__ . '\\render_league_table_block',
+        ] );
+
+        register_block_type( 'tsdb/h2h', [
+            'editor_script' => 'tsdb-h2h',
+            'script'        => 'tsdb-h2h',
+            'render_callback' => __NAMESPACE__ . '\\render_h2h_block',
+        ] );
+
+        register_block_type( 'tsdb/tv-schedule', [
+            'editor_script' => 'tsdb-tv-schedule',
+            'script'        => 'tsdb-tv-schedule',
+            'render_callback' => __NAMESPACE__ . '\\render_tv_schedule_block',
         ] );
     }
 }
@@ -106,4 +176,88 @@ function render_live_standings_block( $attributes = [] ) {
         'status' => $status,
     ];
     return '<div class="tsdb-live-standings" data-tsdb="' . esc_attr( wp_json_encode( $data ) ) . '"></div>';
+}
+
+/**
+ * Server-side render callback for team block.
+ *
+ * @param array $attributes Block attributes.
+ * @return string HTML markup for block container.
+ */
+function render_team_block( $attributes = [] ) {
+    $team   = isset( $attributes['team'] ) ? intval( $attributes['team'] ) : 0;
+    $status = isset( $attributes['status'] ) ? sanitize_text_field( $attributes['status'] ) : 'live';
+    $data   = [
+        'team'   => $team,
+        'status' => $status,
+    ];
+    return '<div class="tsdb-team" data-tsdb="' . esc_attr( wp_json_encode( $data ) ) . '"></div>';
+}
+
+/**
+ * Server-side render callback for player block.
+ *
+ * @param array $attributes Block attributes.
+ * @return string HTML markup for block container.
+ */
+function render_player_block( $attributes = [] ) {
+    $player = isset( $attributes['player'] ) ? intval( $attributes['player'] ) : 0;
+    $status = isset( $attributes['status'] ) ? sanitize_text_field( $attributes['status'] ) : 'live';
+    $data   = [
+        'player' => $player,
+        'status' => $status,
+    ];
+    return '<div class="tsdb-player" data-tsdb="' . esc_attr( wp_json_encode( $data ) ) . '"></div>';
+}
+
+/**
+ * Server-side render callback for league table block.
+ *
+ * @param array $attributes Block attributes.
+ * @return string HTML markup for block container.
+ */
+function render_league_table_block( $attributes = [] ) {
+    $league = isset( $attributes['league'] ) ? intval( $attributes['league'] ) : 0;
+    $season = isset( $attributes['season'] ) ? sanitize_text_field( $attributes['season'] ) : '';
+    $status = isset( $attributes['status'] ) ? sanitize_text_field( $attributes['status'] ) : 'live';
+    $data   = [
+        'league' => $league,
+        'season' => $season,
+        'status' => $status,
+    ];
+    return '<div class="tsdb-league-table" data-tsdb="' . esc_attr( wp_json_encode( $data ) ) . '"></div>';
+}
+
+/**
+ * Server-side render callback for head-to-head block.
+ *
+ * @param array $attributes Block attributes.
+ * @return string HTML markup for block container.
+ */
+function render_h2h_block( $attributes = [] ) {
+    $team1  = isset( $attributes['team1'] ) ? intval( $attributes['team1'] ) : 0;
+    $team2  = isset( $attributes['team2'] ) ? intval( $attributes['team2'] ) : 0;
+    $status = isset( $attributes['status'] ) ? sanitize_text_field( $attributes['status'] ) : 'live';
+    $data   = [
+        'team1'  => $team1,
+        'team2'  => $team2,
+        'status' => $status,
+    ];
+    return '<div class="tsdb-h2h" data-tsdb="' . esc_attr( wp_json_encode( $data ) ) . '"></div>';
+}
+
+/**
+ * Server-side render callback for TV schedule block.
+ *
+ * @param array $attributes Block attributes.
+ * @return string HTML markup for block container.
+ */
+function render_tv_schedule_block( $attributes = [] ) {
+    $country = isset( $attributes['country'] ) ? sanitize_text_field( $attributes['country'] ) : '';
+    $status  = isset( $attributes['status'] ) ? sanitize_text_field( $attributes['status'] ) : 'live';
+    $data    = [
+        'country' => $country,
+        'status'  => $status,
+    ];
+    return '<div class="tsdb-tv-schedule" data-tsdb="' . esc_attr( wp_json_encode( $data ) ) . '"></div>';
 }

--- a/wp-tsdb/includes/shortcodes.php
+++ b/wp-tsdb/includes/shortcodes.php
@@ -15,6 +15,11 @@ function register_shortcodes() {
     add_shortcode( 'tsdb_live_fixtures', __NAMESPACE__ . '\\shortcode_live_fixtures' );
     add_shortcode( 'tsdb_live_event', __NAMESPACE__ . '\\shortcode_live_event' );
     add_shortcode( 'tsdb_live_standings', __NAMESPACE__ . '\\shortcode_live_standings' );
+    add_shortcode( 'tsdb_team', __NAMESPACE__ . '\\shortcode_team' );
+    add_shortcode( 'tsdb_player', __NAMESPACE__ . '\\shortcode_player' );
+    add_shortcode( 'tsdb_league_table', __NAMESPACE__ . '\\shortcode_league_table' );
+    add_shortcode( 'tsdb_h2h', __NAMESPACE__ . '\\shortcode_h2h' );
+    add_shortcode( 'tsdb_tv_schedule', __NAMESPACE__ . '\\shortcode_tv_schedule' );
 }
 add_action( 'init', __NAMESPACE__ . '\\register_shortcodes' );
 
@@ -80,4 +85,111 @@ function shortcode_live_standings( $atts ) {
     );
     wp_enqueue_script( 'tsdb-live-standings' );
     return '<div class="tsdb-live-standings" data-tsdb="' . esc_attr( wp_json_encode( $atts ) ) . '"></div>';
+}
+
+/**
+ * Render team info via shortcode.
+ *
+ * Usage: [tsdb_team team="123" status="live"]
+ *
+ * @param array $atts Shortcode attributes.
+ * @return string
+ */
+function shortcode_team( $atts ) {
+    $atts = shortcode_atts(
+        [
+            'team'   => 0,
+            'status' => 'live',
+        ],
+        $atts,
+        'tsdb_team'
+    );
+    wp_enqueue_script( 'tsdb-team' );
+    return '<div class="tsdb-team" data-tsdb="' . esc_attr( wp_json_encode( $atts ) ) . '"></div>';
+}
+
+/**
+ * Render player info via shortcode.
+ *
+ * Usage: [tsdb_player player="123" status="live"]
+ *
+ * @param array $atts Shortcode attributes.
+ * @return string
+ */
+function shortcode_player( $atts ) {
+    $atts = shortcode_atts(
+        [
+            'player' => 0,
+            'status' => 'live',
+        ],
+        $atts,
+        'tsdb_player'
+    );
+    wp_enqueue_script( 'tsdb-player' );
+    return '<div class="tsdb-player" data-tsdb="' . esc_attr( wp_json_encode( $atts ) ) . '"></div>';
+}
+
+/**
+ * Render league table via shortcode.
+ *
+ * Usage: [tsdb_league_table league="123" season="2023" status="live"]
+ *
+ * @param array $atts Shortcode attributes.
+ * @return string
+ */
+function shortcode_league_table( $atts ) {
+    $atts = shortcode_atts(
+        [
+            'league' => 0,
+            'season' => '',
+            'status' => 'live',
+        ],
+        $atts,
+        'tsdb_league_table'
+    );
+    wp_enqueue_script( 'tsdb-league-table' );
+    return '<div class="tsdb-league-table" data-tsdb="' . esc_attr( wp_json_encode( $atts ) ) . '"></div>';
+}
+
+/**
+ * Render head-to-head via shortcode.
+ *
+ * Usage: [tsdb_h2h team1="1" team2="2" status="live"]
+ *
+ * @param array $atts Shortcode attributes.
+ * @return string
+ */
+function shortcode_h2h( $atts ) {
+    $atts = shortcode_atts(
+        [
+            'team1'  => 0,
+            'team2'  => 0,
+            'status' => 'live',
+        ],
+        $atts,
+        'tsdb_h2h'
+    );
+    wp_enqueue_script( 'tsdb-h2h' );
+    return '<div class="tsdb-h2h" data-tsdb="' . esc_attr( wp_json_encode( $atts ) ) . '"></div>';
+}
+
+/**
+ * Render TV schedule via shortcode.
+ *
+ * Usage: [tsdb_tv_schedule country="US" status="live"]
+ *
+ * @param array $atts Shortcode attributes.
+ * @return string
+ */
+function shortcode_tv_schedule( $atts ) {
+    $atts = shortcode_atts(
+        [
+            'country' => '',
+            'status'  => 'live',
+        ],
+        $atts,
+        'tsdb_tv_schedule'
+    );
+    wp_enqueue_script( 'tsdb-tv-schedule' );
+    return '<div class="tsdb-tv-schedule" data-tsdb="' . esc_attr( wp_json_encode( $atts ) ) . '"></div>';
 }


### PR DESCRIPTION
## Summary
- register new blocks for team, player, league table, H2H and TV schedule
- add matching shortcodes and server-side render callbacks
- implement frontend scripts that fetch `/team`, `/player`, `/standings`, `/h2h` and `/tv`

## Testing
- `php -l includes/blocks.php`
- `php -l includes/shortcodes.php`
- `node --check blocks/team.js`
- `node --check blocks/player.js && node --check blocks/league-table.js && node --check blocks/h2h.js && node --check blocks/tv-schedule.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb9269ddc48328aaea540102e2d257