### PR TITLE
Split REST API permission checks

### DIFF
--- a/wp-tsdb/includes/rest-api.php
+++ b/wp-tsdb/includes/rest-api.php
@@ -35,37 +35,37 @@ class Rest_API {
             register_rest_route( 'tsdb/v1', '/leagues', [
                 'methods'  => 'GET',
                 'callback' => [ $this, 'get_leagues' ],
-                'permission_callback' => [ $this, 'permissions_check' ],
+                'permission_callback' => [ $this, 'permissions_check_admin' ],
             ] );
             register_rest_route( 'tsdb/v1', '/fixtures', [
                 'methods'  => 'GET',
                 'callback' => [ $this, 'get_fixtures' ],
-                'permission_callback' => [ $this, 'permissions_check' ],
+                'permission_callback' => [ $this, 'permissions_check_public' ],
             ] );
             register_rest_route( 'tsdb/v1', '/ref/countries', [
                 'methods'  => 'GET',
                 'callback' => [ $this, 'remote_countries' ],
-                'permission_callback' => [ $this, 'permissions_check' ],
+                'permission_callback' => [ $this, 'permissions_check_admin' ],
             ] );
             register_rest_route( 'tsdb/v1', '/ref/sports', [
                 'methods'  => 'GET',
                 'callback' => [ $this, 'remote_sports' ],
-                'permission_callback' => [ $this, 'permissions_check' ],
+                'permission_callback' => [ $this, 'permissions_check_admin' ],
             ] );
             register_rest_route( 'tsdb/v1', '/ref/leagues', [
                 'methods'  => 'GET',
                 'callback' => [ $this, 'remote_leagues' ],
-                'permission_callback' => [ $this, 'permissions_check' ],
+                'permission_callback' => [ $this, 'permissions_check_admin' ],
             ] );
             register_rest_route( 'tsdb/v1', '/ref/seasons', [
                 'methods'  => 'GET',
                 'callback' => [ $this, 'remote_seasons' ],
-                'permission_callback' => [ $this, 'permissions_check' ],
+                'permission_callback' => [ $this, 'permissions_check_admin' ],
             ] );
             register_rest_route( 'tsdb/v1', '/live', [
                 'methods'  => 'GET',
                 'callback' => [ $this, 'get_live' ],
-                'permission_callback' => [ $this, 'permissions_check' ],
+                'permission_callback' => [ $this, 'permissions_check_public' ],
                 'args'     => [
                     'league' => [
                         'description'       => 'Internal league ID.',
@@ -77,7 +77,7 @@ class Rest_API {
             register_rest_route( 'tsdb/v1', '/standings', [
                 'methods'  => 'GET',
                 'callback' => [ $this, 'get_standings' ],
-                'permission_callback' => [ $this, 'permissions_check' ],
+                'permission_callback' => [ $this, 'permissions_check_public' ],
                 'args'     => [
                     'league' => [
                         'description'       => 'External league ID.',
@@ -95,7 +95,7 @@ class Rest_API {
             register_rest_route( 'tsdb/v1', '/team/(?P<id>\d+)', [
                 'methods'  => 'GET',
                 'callback' => [ $this, 'get_team' ],
-                'permission_callback' => [ $this, 'permissions_check' ],
+                'permission_callback' => [ $this, 'permissions_check_public' ],
                 'args'     => [
                     'id' => [
                         'description'       => 'Team external ID.',
@@ -108,7 +108,7 @@ class Rest_API {
             register_rest_route( 'tsdb/v1', '/team/(?P<id>\d+)/players', [
                 'methods'  => 'GET',
                 'callback' => [ $this, 'get_players' ],
-                'permission_callback' => [ $this, 'permissions_check' ],
+                'permission_callback' => [ $this, 'permissions_check_public' ],
                 'args'     => [
                     'id' => [
                         'description'       => 'Team external ID.',
@@ -121,7 +121,7 @@ class Rest_API {
             register_rest_route( 'tsdb/v1', '/venue/(?P<id>\d+)', [
                 'methods'  => 'GET',
                 'callback' => [ $this, 'get_venue' ],
-                'permission_callback' => [ $this, 'permissions_check' ],
+                'permission_callback' => [ $this, 'permissions_check_public' ],
                 'args'     => [
                     'id' => [
                         'description'       => 'Venue external ID.',
@@ -134,7 +134,7 @@ class Rest_API {
             register_rest_route( 'tsdb/v1', '/event/(?P<id>\d+)', [
                 'methods'  => 'GET',
                 'callback' => [ $this, 'get_event' ],
-                'permission_callback' => [ $this, 'permissions_check' ],
+                'permission_callback' => [ $this, 'permissions_check_public' ],
                 'args'     => [
                     'id' => [
                         'description'       => 'Event external ID.',
@@ -147,7 +147,7 @@ class Rest_API {
             register_rest_route( 'tsdb/v1', '/h2h', [
                 'methods'  => 'GET',
                 'callback' => [ $this, 'get_h2h' ],
-                'permission_callback' => [ $this, 'permissions_check' ],
+                'permission_callback' => [ $this, 'permissions_check_public' ],
                 'args'     => [
                     'team1' => [
                         'description'       => 'First team internal ID.',
@@ -166,7 +166,7 @@ class Rest_API {
             register_rest_route( 'tsdb/v1', '/tv', [
                 'methods'  => 'GET',
                 'callback' => [ $this, 'get_tv' ],
-                'permission_callback' => [ $this, 'permissions_check' ],
+                'permission_callback' => [ $this, 'permissions_check_public' ],
                 'args'     => [
                     'country' => [
                         'description'       => 'Country code for TV listings.',
@@ -178,7 +178,7 @@ class Rest_API {
             register_rest_route( 'tsdb/v1', '/broadcast', [
                 'methods'  => 'GET',
                 'callback' => [ $this, 'get_broadcast' ],
-                'permission_callback' => [ $this, 'permissions_check' ],
+                'permission_callback' => [ $this, 'permissions_check_public' ],
                 'args'     => [
                     'event' => [
                         'description'       => 'Event external ID.',
@@ -191,12 +191,20 @@ class Rest_API {
             register_rest_route( 'tsdb/v1', '/cache', [
                 'methods'  => 'DELETE',
                 'callback' => [ $this, 'purge_cache' ],
-                'permission_callback' => [ $this, 'permissions_check' ],
+                'permission_callback' => [ $this, 'permissions_check_admin' ],
             ] );
         } );
     }
 
-    public function permissions_check( $request ) {
+    public function permissions_check_public( $request ) {
+        $nonce = $request->get_header( 'X-WP-Nonce' );
+        if ( $nonce && ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
+            return false;
+        }
+        return true;
+    }
+
+    public function permissions_check_admin( $request ) {
         $nonce = $request->get_header( 'X-WP-Nonce' );
         return $nonce && wp_verify_nonce( $nonce, 'tsdb_sync' ) && current_user_can( 'manage_options' );
     }


### PR DESCRIPTION
## Summary
- Divide REST API permission checks into public and admin variants
- Use relaxed public checks for block and shortcode GET routes
- Keep strict admin checks for maintenance endpoints

## Testing
- `php -l wp-tsdb/includes/rest-api.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc0ca0270883289c6e090b3a81c400