### PR TITLE
Use ETag responses for leagues and fixtures

### DIFF
--- a/wp-tsdb/includes/rest-api.php
+++ b/wp-tsdb/includes/rest-api.php
@@ -245,7 +245,7 @@ class Rest_API {
         foreach ( $rows as $row ) {
             $row->logo_url = $row->logo_id ? wp_get_attachment_url( $row->logo_id ) : null;
         }
-        return rest_ensure_response( $rows );
+        return $this->etag_response( $request, $rows );
     }
 
     public function get_fixtures( $request ) {
@@ -286,7 +286,7 @@ class Rest_API {
             $row->home_badge = isset( $badges[ $row->home_id ] ) && $badges[ $row->home_id ] ? wp_get_attachment_url( $badges[ $row->home_id ] ) : null;
             $row->away_badge = isset( $badges[ $row->away_id ] ) && $badges[ $row->away_id ] ? wp_get_attachment_url( $badges[ $row->away_id ] ) : null;
         }
-        return rest_ensure_response( $rows );
+        return $this->etag_response( $request, $rows );
     }
 
     /**


### PR DESCRIPTION
## Summary
- Replace `rest_ensure_response` with `etag_response` in `get_leagues` and `get_fixtures` for proper ETag handling
- Preserve existing cache key logic for both endpoints

## Testing
- `php -l wp-tsdb/includes/rest-api.php`
- `curl -i http://localhost:8000/etag_test.php`
- `curl -i -H 'If-None-Match: "fbc24bcc7a1794758fc1327fcfebdaf6"' http://localhost:8000/etag_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc0cb4aca88328ab8cdb543cb4ddb8