### PR TITLE
Remove unsupported player transfer endpoint

### DIFF
--- a/wp-tsdb/includes/api-client.php
+++ b/wp-tsdb/includes/api-client.php
@@ -185,14 +185,4 @@ class Api_Client {
         return $this->get( '/lookuplineup.php', [ 'id' => $event_id ] );
     }
 
-    /**
-     * Fetch transfer history for a player.
-     *
-     * @param int $player_id External player ID.
-     *
-     * @return array|\WP_Error
-     */
-    public function player_transfers( $player_id ) {
-        return $this->get( '/lookuptransfers.php', [ 'id' => $player_id ], true );
-    }
 }

--- a/wp-tsdb/includes/rest-api.php
+++ b/wp-tsdb/includes/rest-api.php
@@ -20,7 +20,6 @@ class Rest_API {
     const TTL_H2H       = DAY_IN_SECONDS;
     const TTL_TV        = HOUR_IN_SECONDS;
     const TTL_LINEUP    = 10 * MINUTE_IN_SECONDS;
-    const TTL_TRANSFERS = DAY_IN_SECONDS;
 
     public function __construct( Api_Client $api, Cache_Store $cache ) {
         $this->api   = $api;
@@ -153,19 +152,6 @@ class Rest_API {
                 'args'     => [
                     'id' => [
                         'description'       => 'Event external ID.',
-                        'type'              => 'integer',
-                        'required'          => true,
-                        'sanitize_callback' => 'absint',
-                    ],
-                ],
-            ] );
-            register_rest_route( 'tsdb/v1', '/player/(?P<id>\\d+)/transfers', [
-                'methods'  => 'GET',
-                'callback' => [ $this, 'get_transfers' ],
-                'permission_callback' => [ $this, 'permissions_check_public' ],
-                'args'     => [
-                    'id' => [
-                        'description'       => 'Player external ID.',
                         'type'              => 'integer',
                         'required'          => true,
                         'sanitize_callback' => 'absint',
@@ -520,27 +506,6 @@ class Rest_API {
                 $data = [];
             }
             $this->cache->set( $cache_key, $data, self::TTL_PLAYERS );
-        }
-        return $this->etag_response( $request, $data );
-    }
-
-    /**
-     * Retrieve transfer history for a player.
-     *
-     * @param \WP_REST_Request $request Request object.
-     * @return \WP_REST_Response|\WP_Error
-     */
-    public function get_transfers( $request ) {
-        $id        = absint( $request['id'] );
-        $cache_key = 'transfers_' . $id;
-        $data      = $this->cache->get( $cache_key );
-        if ( false === $data ) {
-            $res = $this->api->player_transfers( $id );
-            if ( is_wp_error( $res ) ) {
-                return $res;
-            }
-            $data = $res['transfers'] ?? [];
-            $this->cache->set( $cache_key, $data, self::TTL_TRANSFERS );
         }
         return $this->etag_response( $request, $data );
     }


### PR DESCRIPTION
## Summary
- drop v2 `lookuptransfers.php` calls
- remove player transfer REST route and caching constant

## Testing
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`
- `curl -s https://www.thesportsdb.com/api/v1/json/719472/all_sports.php | jq '.sports[0:3]'`
- `curl -s "https://www.thesportsdb.com/api/v1/json/719472/search_all_leagues.php?c=England&s=Soccer" | jq '.countries[0:2] | map({idLeague, strLeague})'`
- `curl -s "https://www.thesportsdb.com/api/v1/json/719472/search_all_seasons.php?id=4328" | jq '.seasons[0:5] | map({strSeason})'`
- `curl -s "https://www.thesportsdb.com/api/v1/json/719472/lookupevent.php?id=1032866" | jq '.'`
- `curl -s "https://www.thesportsdb.com/api/v1/json/719472/lookuplineup.php?id=1032866" | jq '.lineup'`
- `curl -s https://www.thesportsdb.com/api/v1/json/719472/all_countries.php | jq '.countries[0:5] | map({name:.name_en})'`

------
https://chatgpt.com/codex/tasks/task_e_68bc1d400b5483288c7ab5717ce8f230