### PR TITLE
Remove unsupported player transfer endpoint

### DIFF
--- a/wp-tsdb/includes/admin-ui.php
+++ b/wp-tsdb/includes/admin-ui.php
@@ -57,7 +57,7 @@ class Admin_UI {
             delete_option( 'tsdb_api_key' );
             return '';
         }
-        $encrypted = tsdb_encrypt( $value );
+        $encrypted = \tsdb_encrypt( $value );
         delete_option( 'tsdb_api_key' );
         add_option( 'tsdb_api_key', $encrypted, '', 'no' );
         return $encrypted;
@@ -184,7 +184,7 @@ class Admin_UI {
                 <table class="form-table" role="presentation">
                     <tr>
                         <th scope="row"><label for="tsdb_api_key">API Key</label></th>
-                        <td><input name="tsdb_api_key" type="text" id="tsdb_api_key" value="<?php echo esc_attr( tsdb_get_api_key() ); ?>" class="regular-text"></td>
+                        <td><input name="tsdb_api_key" type="text" id="tsdb_api_key" value="<?php echo esc_attr( \tsdb_get_api_key() ); ?>" class="regular-text"></td>
                     </tr>
                     <tr>
                         <th scope="row"><label for="tsdb_default_sport">Default Sport</label></th>

--- a/wp-tsdb/includes/api-client.php
+++ b/wp-tsdb/includes/api-client.php
@@ -185,14 +185,4 @@ class Api_Client {
         return $this->get( '/lookuplineup.php', [ 'id' => $event_id ] );
     }
 
-    /**
-     * Fetch transfer history for a player.
-     *
-     * @param int $player_id External player ID.
-     *
-     * @return array|\WP_Error
-     */
-    public function player_transfers( $player_id ) {
-        return $this->get( '/lookuptransfers.php', [ 'id' => $player_id ], true );
-    }
 }

--- a/wp-tsdb/includes/rest-api.php
+++ b/wp-tsdb/includes/rest-api.php
@@ -20,7 +20,6 @@ class Rest_API {
     const TTL_H2H       = DAY_IN_SECONDS;
     const TTL_TV        = HOUR_IN_SECONDS;
     const TTL_LINEUP    = 10 * MINUTE_IN_SECONDS;
-    const TTL_TRANSFERS = DAY_IN_SECONDS;
 
     public function __construct( Api_Client $api, Cache_Store $cache ) {
         $this->api   = $api;
@@ -153,19 +152,6 @@ class Rest_API {
                 'args'     => [
                     'id' => [
                         'description'       => 'Event external ID.',
-                        'type'              => 'integer',
-                        'required'          => true,
-                        'sanitize_callback' => 'absint',
-                    ],
-                ],
-            ] );
-            register_rest_route( 'tsdb/v1', '/player/(?P<id>\\d+)/transfers', [
-                'methods'  => 'GET',
-                'callback' => [ $this, 'get_transfers' ],
-                'permission_callback' => [ $this, 'permissions_check_public' ],
-                'args'     => [
-                    'id' => [
-                        'description'       => 'Player external ID.',
                         'type'              => 'integer',
                         'required'          => true,
                         'sanitize_callback' => 'absint',
@@ -520,27 +506,6 @@ class Rest_API {
                 $data = [];
             }
             $this->cache->set( $cache_key, $data, self::TTL_PLAYERS );
-        }
-        return $this->etag_response( $request, $data );
-    }
-
-    /**
-     * Retrieve transfer history for a player.
-     *
-     * @param \WP_REST_Request $request Request object.
-     * @return \WP_REST_Response|\WP_Error
-     */
-    public function get_transfers( $request ) {
-        $id        = absint( $request['id'] );
-        $cache_key = 'transfers_' . $id;
-        $data      = $this->cache->get( $cache_key );
-        if ( false === $data ) {
-            $res = $this->api->player_transfers( $id );
-            if ( is_wp_error( $res ) ) {
-                return $res;
-            }
-            $data = $res['transfers'] ?? [];
-            $this->cache->set( $cache_key, $data, self::TTL_TRANSFERS );
         }
         return $this->etag_response( $request, $data );
     }


### PR DESCRIPTION
## Summary
- drop v2 `lookuptransfers.php` calls
- remove player transfer REST route and caching constant
- reference global helpers for API key encryption to avoid admin fatal

## Testing
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`
- `curl -s https://www.thesportsdb.com/api/v1/json/719472/all_sports.php | jq '.sports[0:3]'`
- `curl -s "https://www.thesportsdb.com/api/v1/json/719472/search_all_leagues.php?c=England&s=Soccer" | jq '.countries[0:2] | map({idLeague, strLeague})'`
- `curl -s "https://www.thesportsdb.com/api/v1/json/719472/search_all_seasons.php?id=4328" | jq '.seasons[0:5] | map({strSeason})'`
- `curl -s "https://www.thesportsdb.com/api/v1/json/719472/lookupevent.php?id=1032866" | jq '.'`
- `curl -s "https://www.thesportsdb.com/api/v1/json/719472/lookuplineup.php?id=1032866" | jq '.lineup'`
- `curl -s https://www.thesportsdb.com/api/v1/json/719472/all_countries.php | jq '.countries[0:5] | map({idCountry, name: .name_en})'`


------
https://chatgpt.com/codex/tasks/task_e_68bc1d400b5483288c7ab5717ce8f230